### PR TITLE
Use uchardet to detect document encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ On Debian/Ubuntu/Mint:
 ```
 apt-get install uchardet libuchardet-dev
 ```
+On Mac:
+```
+brew install uchardet
+```
 
 ## Compile
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # warc2text
 Extracts plain text, language identification and more metadata from WARC records
 
+## Install dependencies
+On Debian/Ubuntu/Mint:
+```
+apt-get install uchardet libuchardet-dev
+```
 
 ## Compile
 ```
@@ -19,3 +24,5 @@ warc2text -o [output folder] [ WARC ... ]
 HTML Tokenizer by [c-smile](https://www.codeproject.com/Articles/14076/Fast-and-Compact-HTML-XML-Scanner-Tokenizer)
 
 HTML entities decoder by [Christoph Gärtner](https://bitbucket.org/cggaertner/cstuff/src/master/entities.c)
+
+Charset detection [uchardet](https://www.freedesktop.org/wiki/Software/uchardet/)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ HTML Tokenizer by [c-smile](https://www.codeproject.com/Articles/14076/Fast-and-
 HTML entities decoder by [Christoph Gärtner](https://bitbucket.org/cggaertner/cstuff/src/master/entities.c)
 
 Charset detection [uchardet](https://www.freedesktop.org/wiki/Software/uchardet/)
-=======
 
 ___
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(warc2text_src)
 
+find_library(UCHARDET uchardet REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package( Boost 1.61 COMPONENTS locale iostreams filesystem log REQUIRED )
 include_directories(
@@ -24,4 +25,5 @@ add_library(warc2text_lib
 target_link_libraries(warc2text_lib
     ${Boost_LIBRARIES}
     ${ZLIB_LIBRARIES}
+    ${UCHARDET}
 )

--- a/src/record.cc
+++ b/src/record.cc
@@ -130,6 +130,9 @@ namespace warc2text {
                 plaintext = "";
                 return false;
             }
+        } else if (charset.empty()) {
+            // throw out documents if we don't know the charset
+            return false;
         }
         unescapeEntities(plaintext, plaintext);
         util::trimLines(plaintext);

--- a/src/record.cc
+++ b/src/record.cc
@@ -12,6 +12,7 @@
 // #include <boost/iostreams/categories.hpp>
 // #include <boost/iostreams/code_converter.hpp>
 #include <boost/locale.hpp>
+#include <uchardet/uchardet.h>
 
 namespace warc2text {
     std::size_t read_header(const std::string& content, std::size_t last_pos, std::unordered_map<std::string,std::string>& header) {
@@ -111,9 +112,17 @@ namespace warc2text {
         // remove HTML tags:
         processHTML(payload, plaintext);
 
-        // convert to utf8
-        // assume utf8 if unknown for now
-        if (charset != "UTF-8" && charset != "") {
+        // detect charset
+        std::string detected_charset;
+        bool detection_result = util::detectCharset(plaintext, detected_charset);
+
+        // trust the detected more than the specified charset
+        // if detection fails, go with the original one
+        if (detection_result)
+            charset = detected_charset;
+
+        // attempt conversion is we know the charset, and it is not utf8/ascii
+        if (charset != "" && charset != "utf-8" && charset != "ascii" && charset != "utf8") {
             try {
                 plaintext = boost::locale::conv::to_utf<char>(plaintext, charset);
             } catch (const boost::locale::conv::invalid_charset_error& e) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -3,6 +3,7 @@
 #include <boost/algorithm/string/trim_all.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
+#include <uchardet/uchardet.h>
 
 namespace util {
     void toLower(std::string& s){
@@ -34,6 +35,19 @@ namespace util {
             first = last + 1;
             last = std::find(first, original.end(), '\n');
         }
+    }
+
+    bool detectCharset(const std::string& text, std::string& charset){
+        uchardet_t handle = uchardet_new();
+        int chardet_result = uchardet_handle_data(handle, text.c_str(), text.size());
+        uchardet_data_end(handle);
+        bool success = (chardet_result == 0);
+        if (success){
+            charset = uchardet_get_charset(handle);
+            toLower(charset);
+        }
+        uchardet_delete(handle);
+        return (success && !charset.empty());
     }
 
     void encodeBase64(const std::string& original, std::string& base64){

--- a/src/util.hh
+++ b/src/util.hh
@@ -15,6 +15,9 @@ namespace util {
     void trimLines(std::string& text);
     void trimLinesCopy(const std::string& original, std::string& result);
 
+    // detect charset using uchardet
+    bool detectCharset(const std::string& text, std::string& charset);
+
     typedef boost::archive::iterators::base64_from_binary<
         boost::archive::iterators::transform_width<
             std::string::const_iterator,

--- a/src/warcpreprocessor.cc
+++ b/src/warcpreprocessor.cc
@@ -29,6 +29,9 @@ namespace warc2text {
                 continue;
 
             Record record(content);
+            if (record.getPayload().empty())
+                continue;
+
             if ((record.getRecordType() != "response" && record.getRecordType() != "resource") || record.getWARCcontentType().find("application/http") == std::string::npos)
                 continue;
 


### PR DESCRIPTION
* Use uchardet to detect encoding of documents after HTML cleaning
* The detected encoding is preferred over the charset found in HTTP header
* If no encoding is found/detect, document is removed