### PR TITLE
Filter out documents that contain tags that could indicate machine translation

### DIFF
--- a/src/html.cc
+++ b/src/html.cc
@@ -1,5 +1,4 @@
 #include "html.hh"
-#include <unordered_map>
 
 namespace warc2text {
 

--- a/src/html.hh
+++ b/src/html.hh
@@ -10,7 +10,7 @@ extern "C" {
 }
 
 namespace warc2text {
-    void processHTML(const std::string& html, std::string& text);
+    int processHTML(const std::string& html, std::string& text);
 
     void unescapeEntities(const std::string& text, std::string& processed);
 }

--- a/src/html.hh
+++ b/src/html.hh
@@ -5,12 +5,13 @@
 #include <cstring>
 #include <string>
 #include "xh_scanner.hh"
+#include "util.hh"
 extern "C" {
     #include "entities.h"
 }
 
 namespace warc2text {
-    int processHTML(const std::string& html, std::string& text);
+    int processHTML(const std::string& html, std::string& text, const util::umap_tag_filters& tagFilters);
 
     void unescapeEntities(const std::string& text, std::string& processed);
 }

--- a/src/record.cc
+++ b/src/record.cc
@@ -127,12 +127,14 @@ namespace warc2text {
                 plaintext = boost::locale::conv::to_utf<char>(plaintext, charset);
             } catch (const boost::locale::conv::invalid_charset_error& e) {
                 BOOST_LOG_TRIVIAL(warning) << "In record " << url << " invalid charset " << charset;
-                plaintext = "";
+                return util::UNKNOWN_ENCODING_ERROR;
+            } catch (const boost::locale::conv::conversion_error& e) {
+                BOOST_LOG_TRIVIAL(warning) << "In record " << url << " conversion error from " << charset;
                 return util::UTF8_CONVERSION_ERROR;
             }
         } else if (charset.empty()) {
             // throw out documents if we don't know the charset
-            return false;
+            return util::UNKNOWN_ENCODING_ERROR;
         }
         unescapeEntities(plaintext, plaintext);
         util::trimLines(plaintext);

--- a/src/record.cc
+++ b/src/record.cc
@@ -107,9 +107,9 @@ namespace warc2text {
         util::trim(cleanHTTPcontentType);
     }
 
-    bool Record::cleanPayload(){
+    int Record::cleanPayload(){
         // remove HTML tags:
-        processHTML(payload, plaintext);
+        int retval = processHTML(payload, plaintext);
 
         // convert to utf8
         // assume utf8 if unknown for now
@@ -119,12 +119,12 @@ namespace warc2text {
             } catch (const boost::locale::conv::invalid_charset_error& e) {
                 BOOST_LOG_TRIVIAL(warning) << "In record " << url << " invalid charset " << charset;
                 plaintext = "";
-                return false;
+                return util::UTF8_CONVERSION_ERROR;
             }
         }
         unescapeEntities(plaintext, plaintext);
         util::trimLines(plaintext);
-        return true;
+        return retval;
     }
 
     bool Record::detectLanguage(){

--- a/src/record.hh
+++ b/src/record.hh
@@ -29,7 +29,7 @@ namespace warc2text {
         const std::string& getHTTPcontentType() const;
         const std::string& getCharset() const;
 
-        bool cleanPayload();
+        int cleanPayload();
         bool detectLanguage();
 
     private:

--- a/src/record.hh
+++ b/src/record.hh
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <unordered_map>
+#include "util.hh"
 
 namespace warc2text {
     class Record {
@@ -30,6 +31,7 @@ namespace warc2text {
         const std::string& getCharset() const;
 
         int cleanPayload();
+        int cleanPayload(const util::umap_tag_filters& tagFilters);
         bool detectLanguage();
 
     private:

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,8 +1,12 @@
 #include "util.hh"
+#include <iostream>
+#include <fstream>
 #include <algorithm>
+#include <vector>
 #include <boost/algorithm/string/trim_all.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
+#include <boost/algorithm/string/split.hpp>
 #include <uchardet/uchardet.h>
 
 namespace util {
@@ -56,4 +60,20 @@ namespace util {
         base64.append(pad, '=');
     }
 
+    void readTagFilters(const std::string& filename, umap_tag_filters& filters) {
+        std::ifstream f(filename);
+        std::string line;
+        std::vector<std::string> fields;
+        while (std::getline(f, line)) {
+            fields.clear();
+            boost::algorithm::split(fields, line, [](char c){return c == '\t';});
+            if (fields.size() < 3)
+                break;
+            umap_attr_filters& attrs = filters[fields.at(0)];
+            std::unordered_set<std::string>& values = attrs[fields.at(1)];
+            for (unsigned int i = 2; i < fields.size(); ++i)
+                values.insert(fields.at(i));
+        }
+        f.close();
+    }
 }

--- a/src/util.hh
+++ b/src/util.hh
@@ -28,7 +28,6 @@ namespace util {
 
     void encodeBase64(const std::string& original, std::string& base64);
 
-
     enum ErrorCode : int {
         SUCCESS = 0,
         HTML_PARSING_ERROR = 1,

--- a/src/util.hh
+++ b/src/util.hh
@@ -2,6 +2,8 @@
 #define WARC2TEXT_UTIL_HH
 
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
 
@@ -35,6 +37,12 @@ namespace util {
         UNKNOWN_ENCODING_ERROR = 3,
         UTF8_CONVERSION_ERROR = 4
     };
+
+
+    typedef std::unordered_map<std::string, std::unordered_set<std::string>> umap_attr_filters;
+    typedef std::unordered_map<std::string, umap_attr_filters> umap_tag_filters;
+
+    void readTagFilters(const std::string& filename, umap_tag_filters& filters);
 }
 
 #endif

--- a/src/util.hh
+++ b/src/util.hh
@@ -25,6 +25,14 @@ namespace util {
 
     void encodeBase64(const std::string& original, std::string& base64);
 
+
+    enum ErrorCode : int {
+        SUCCESS = 0,
+        HTML_PARSING_ERROR = 1,
+        FILTERED_DOCUMENT_ERROR = 2,
+        UNKNOWN_ENCODING_ERROR = 3,
+        UTF8_CONVERSION_ERROR = 4
+    };
 }
 
 #endif

--- a/src/warcpreprocessor.hh
+++ b/src/warcpreprocessor.hh
@@ -4,6 +4,7 @@
 #include "record.hh"
 #include "warcreader.hh"
 #include "bilangwriter.hh"
+#include "util.hh"
 #include <string>
 #include <unordered_set>
 
@@ -18,9 +19,10 @@ namespace warc2text {
             unsigned int textBytes;
             unsigned int langBytes;
             static const std::unordered_set<std::string> textContentTypes;
+            util::umap_tag_filters tagFilters;
 
         public:
-            explicit WARCPreprocessor(const std::string& outputFolder);
+            explicit WARCPreprocessor(const std::string& outputFolder, const std::string& tagFiltersFile = "");
             void process(const std::string &filename);
             void printStatistics() const;
     };

--- a/src/xh_scanner.cc
+++ b/src/xh_scanner.cc
@@ -68,12 +68,18 @@ namespace markup {
         char c = skip_whitespace();
 
         if (c == '>') {
-            c_scan = &scanner::scan_body;
+            if (equal(tag_name, "script", 6))
+                // script is special because we want to parse the attributes,
+                // but not the content
+                c_scan = &scanner::scan_script;
+            else
+                c_scan = &scanner::scan_body;
             return scan_body();
         }
         if (c == '/') {
             char t = get_char();
             if (t == '>') {
+                // self closing tag
                 c_scan = &scanner::scan_body;
                 return TT_TAG_END;
             }
@@ -169,12 +175,6 @@ namespace markup {
                     if (equal(tag_name, "!--", 3)) {
                         c_scan = &scanner::scan_comment;
                         return TT_COMMENT_START;
-                    }
-                    break;
-                case 6:
-                    if (equal(tag_name, "script", 6)) {
-                        c_scan = &scanner::scan_script;
-                        return TT_SCRIPT_START;
                     }
                     break;
                 case 8:
@@ -310,7 +310,7 @@ namespace markup {
         if (got_tail) {
             c_scan = &scanner::scan_body;
             got_tail = false;
-            return TT_SCRIPT_END;
+            return TT_TAG_END;
         }
         for (value_length = 0; value_length < (MAX_TOKEN_SIZE - 1); ++value_length) {
             char c = get_char();

--- a/src/xh_scanner.hh
+++ b/src/xh_scanner.hh
@@ -28,12 +28,12 @@ namespace markup {
             TT_SPACE,
 
             TT_DATA,        // content of followings:
+            // (also content of TT_TAG_START and TT_TAG_END, if the tag is 'script')
 
             TT_COMMENT_START, TT_COMMENT_END, // after "<!--" and "-->"
             TT_CDATA_START, TT_CDATA_END,     // after "<![CDATA[" and "]]>"
             TT_PI_START, TT_PI_END,           // after "<?" and "?>"
             TT_ENTITY_START, TT_ENTITY_END,   // after "<!ENTITY" and ">"
-            TT_SCRIPT_START, TT_SCRIPT_END,   // after "<script" and "</script>"
 
         };
 

--- a/tags_filters
+++ b/tags_filters
@@ -3,3 +3,6 @@ link	id	gtranslate-style-css
 meta	name	translation-stats
 script	src	gtranslate
 aside	id	gtranslate
+div	id	gtranslate
+div	id	google_translate_element
+div	id	google_translate_element2

--- a/tags_filters
+++ b/tags_filters
@@ -1,0 +1,5 @@
+link	rel	alternate-machine-translated-from
+link	id	gtranslate-style-css
+meta	name	translation-stats
+script	src	gtranslate
+aside	id	gtranslate

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -15,6 +15,7 @@ struct Options {
     std::vector<std::string> warcs;
     bool verbose;
     std::string output;
+    std::string tag_filters_filename;
 };
 
 void parseArgs(int argc, char *argv[], Options& out) {
@@ -24,7 +25,8 @@ void parseArgs(int argc, char *argv[], Options& out) {
         ("help,h", po::bool_switch(), "Show this help message")
         ("output,o", po::value(&out.output)->default_value("."), "Output folder")
         ("input,i", po::value(&out.warcs)->multitoken(), "Input WARC file name(s)")
-        ("verbose,v", po::bool_switch(&out.verbose), "Verbosity level");
+        ("tag-filters", po::value(&out.tag_filters_filename), "Plain text file containing tag filters")
+        ("verbose,v", po::bool_switch(&out.verbose)->default_value(""), "Verbosity level");
 
     po::positional_options_description pd;
     pd.add("input", -1);
@@ -52,7 +54,7 @@ int main(int argc, char *argv[]) {
 
     std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
 
-    WARCPreprocessor warcpproc(options.output);
+    WARCPreprocessor warcpproc(options.output, options.tag_filters_filename);
     for (std::string file : options.warcs){
         warcpproc.process(file);
     }

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -34,7 +34,11 @@ void parseArgs(int argc, char *argv[], Options& out) {
     po::variables_map vm;
     po::store(po::command_line_parser(argc, argv).options(desc).positional(pd).run(), vm);
     if (argc == 1 || vm["help"].as<bool>()) {
-        std::cerr << "Usage: " << argv[0] << " -o output_folder [WARC_files]" << std::endl;
+        std::cerr << "Usage: " << argv[0] << " -o <output_folder> [--tag-filters <filters_file>] <warc_file>...\n"
+                "\n"
+                "Options:\n"
+                " -o                Output folder, required\n"
+                " --tag-filters     File containing filters, format: \"html_tag <tab> tag_attr <tab> value\"\n";
         exit(1);
     }
     po::notify(vm);


### PR DESCRIPTION
* Format of the filters have the following format:
  `tag <tab> attribute <tab> value <tab> value ...`
  For example, `meta name translation-stats` will filter out documents that contain: `<meta name="translation-stats" ... >`.
  The filter functionality checks that the value of `name` attribute contains the specified string, not that they are equal. So, the filter `meta name translation` would also eliminate a document with `<meta name="translation-stats" ...>`.
* The documents that contain filter tags are not outputted, and a message with the URL of the filtered record is shown on the console
* `--tag-filter` to pass the filters file