### PR TITLE
Write PDF records to a separate WARC file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ make
 warc2text -o [output folder] [ WARC ... ]
 ```
 * `--output`/`-o` output folder
-* `--tag-filters` file containig filters that to eliminate some documents
 
+* `--files`/`-f` list of output files separated by commas (and without `.gz`); `text` and `url` are always written, while `mime` and `html` are optional
+* `--pdfpass` WARC file where PDF records will be stored
+* `--tag-filters` file containig filters that to eliminate some documents
+  
   Filter format is the following: `tag <tab> attribute <tab> value ...`
   
   For example, `meta <tab> name <tab> translation-stats` will remove documents that contain `<meta name="translation-stats" ... >`

--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -3,11 +3,6 @@
 #include <cassert>
 
 namespace warc2text{
-    bool createDirectories(const std::string& path){
-        if (!boost::filesystem::exists(path))
-            return boost::filesystem::create_directories(path);
-        else return false; // throw exception??
-    }
 
     GzipWriter::GzipWriter() {
         dest = NULL;
@@ -21,8 +16,11 @@ namespace warc2text{
     }
 
     GzipWriter::~GzipWriter() {
-        this->compress("", 0, Z_FINISH);
-        deflateEnd(&s);
+        if (dest) {
+            this->compress("", 0, Z_FINISH);
+            deflateEnd(&s);
+            std::fclose(dest);
+        }
         delete[] buf;
     }
 
@@ -77,7 +75,7 @@ namespace warc2text{
         if (!url->is_open()) {
             // if one file does not exist, the rest shouldn't either
             std::string path = folder + "/" + *lang;
-            createDirectories(path);
+            util::createDirectories(path);
             url->open(path + "/url.gz");
             text->open(path + "/text.gz");
             if (mime != NULL) mime->open(path + "/mime.gz");

--- a/src/bilangwriter.hh
+++ b/src/bilangwriter.hh
@@ -3,12 +3,10 @@
 
 #include <unordered_map>
 #include <unordered_set>
-#include <boost/filesystem.hpp>
 #include "record.hh"
 #include "zlib.h"
 
 namespace warc2text {
-    bool createDirectories(const std::string& path);
 
     class GzipWriter {
         private:

--- a/src/util.cc
+++ b/src/util.cc
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <algorithm>
 #include <vector>
+#include <boost/filesystem.hpp>
 #include <boost/algorithm/string/trim_all.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
@@ -100,6 +101,12 @@ namespace util {
                 values.emplace_back(fields.at(i));
         }
         f.close();
+    }
+
+    bool createDirectories(const std::string& path){
+        if (!boost::filesystem::exists(path))
+            return boost::filesystem::create_directories(path);
+        else return false; // throw exception??
     }
 
 }

--- a/src/util.hh
+++ b/src/util.hh
@@ -43,6 +43,8 @@ namespace util {
     typedef std::unordered_map<std::string, umap_attr_filters> umap_tag_filters;
 
     void readTagFilters(const std::string& filename, umap_tag_filters& filters);
+
+    bool createDirectories(const std::string& path);
 }
 
 namespace html {

--- a/src/warcpreprocessor.hh
+++ b/src/warcpreprocessor.hh
@@ -19,13 +19,13 @@ namespace warc2text {
             unsigned int textBytes;
             unsigned int langBytes;
             util::umap_tag_filters tagFilters;
-            std::unordered_set<std::string> output_files;
             static const std::unordered_set<std::string> textContentTypes;
             static const std::unordered_set<std::string> removeExtensions;
             static bool URLfilter(const std::string& url);
+            std::string pdf_warc_filename;
 
         public:
-            explicit WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files = {}, const std::string& tagFiltersFile = "");
+            explicit WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files = {}, const std::string pdf_warc_filename = "", const std::string& tagFiltersFile = "");
             void process(const std::string &filename);
             void printStatistics() const;
     };

--- a/src/warcpreprocessor.hh
+++ b/src/warcpreprocessor.hh
@@ -9,6 +9,18 @@
 #include <unordered_set>
 
 namespace warc2text {
+    class WARCWriter {
+        private:
+            FILE* warc;
+            std::string filename;
+        public:
+            WARCWriter();
+            void open(const std::string& warc_filename);
+            void close();
+            bool is_open();
+            void writeRecord(const std::string& content);
+    };
+
     class WARCPreprocessor {
         private:
             BilangWriter writer;

--- a/src/warcreader.cc
+++ b/src/warcreader.cc
@@ -1,5 +1,6 @@
 #include "warcreader.hh"
 #include "record.hh"
+#include <boost/log/trivial.hpp>
 #include <cassert>
 
 namespace warc2text {
@@ -65,9 +66,14 @@ namespace warc2text {
             file = std::freopen(nullptr, "rb", stdin); // make sure stdin is open in binary mode
         else file = std::fopen(filename.c_str(), "r");
         if (!file) {
-            std::perror("File opening failed");
-            exit(1);
+            // std::perror("File opening failed");
+            // exit(1);
+            BOOST_LOG_TRIVIAL(warning) << "WARC " << filename << ": file opening failed, skipping this WARC";
         }
+    }
+
+    void WARCReader::closeFile() {
+        if (file) std::fclose(file);
     }
 
     std::size_t WARCReader::readChunk(){

--- a/src/warcreader.hh
+++ b/src/warcreader.hh
@@ -19,7 +19,7 @@ namespace warc2text {
             uint8_t* scratch;
 
             void openFile(const std::string& filename);
-            void closeFile() {std::fclose(file);}
+            void closeFile();
             std::size_t readChunk();
     };
 }

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -15,6 +15,7 @@ using namespace warc2text;
 struct Options {
     std::vector<std::string> warcs;
     std::string files;
+    std::string pdf_warc_filename;
     bool verbose{};
     std::string output;
     std::string tag_filters_filename;
@@ -29,6 +30,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
         ("files,f", po::value(&out.files)->default_value("url,token"), "List of output files separated by commas. Default (mandatory files): 'url,text'. Optional: 'mime,html'")
         ("input,i", po::value(&out.warcs)->multitoken(), "Input WARC file name(s)")
         ("tag-filters", po::value(&out.tag_filters_filename), "Plain text file containing tag filters")
+        ("pdfpass", po::value(&out.pdf_warc_filename), "Write PDF records to WARC")
         ("verbose,v", po::bool_switch(&out.verbose)->default_value(false), "Verbosity level");
 
     po::positional_options_description pd;
@@ -46,6 +48,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
                 "                                  Optional values: \"mime,html\"\n"
                 " --tag-filters <filters_files>    File containing filters\n"
                 "                                  Format: \"html_tag <tab> tag_attr <tab> value\"\n"
+                " --pdfpass <output_warc>          Write PDF records to <output_warc>\n"
                 " -v                               Verbose output (print trace)\n\n";
         exit(1);
     }
@@ -70,7 +73,7 @@ int main(int argc, char *argv[]) {
     std::unordered_set<std::string> output_files(files_list.begin(), files_list.end());
 
     std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-    WARCPreprocessor warcpproc(options.output, output_files, options.tag_filters_filename);
+    WARCPreprocessor warcpproc(options.output, output_files, options.pdf_warc_filename, options.tag_filters_filename);
     for (const std::string& file : options.warcs){
         warcpproc.process(file);
     }


### PR DESCRIPTION
Enable this functionality by providing a filename for WARC output via `--pdfpass` option