### PR TITLE
New options

### DIFF
--- a/src/html.cc
+++ b/src/html.cc
@@ -1,6 +1,7 @@
 #include <cstring>
 #include <unordered_set>
 #include <regex>
+#include <boost/log/trivial.hpp>
 #include "util.hh"
 #include "html.hh"
 #include "xh_scanner.hh"
@@ -15,9 +16,12 @@ namespace warc2text {
         util::umap_attr_filters_regex::const_iterator attr_it = tag_it->second.find(util::toLowerCopy(attr));
         if (attr_it == tag_it->second.cend())
             return true;
-        for (const std::regex& filter : attr_it->second){
-            if (std::regex_search(value, filter))
+        for (const util::umap_attr_regex& filter : attr_it->second){
+            std::cmatch match;
+            if (std::regex_search(value, match, filter.regex)) {
+                BOOST_LOG_TRIVIAL(debug) << "Tag filter " << tag_it->first << "[" << attr_it->first << " ~ " << filter.str << "] matched '" << match.str() << "' in value '" << value << "'";
                 return false;
+            }
         }
         return true;
     }

--- a/src/util.cc
+++ b/src/util.cc
@@ -113,9 +113,12 @@ namespace util {
             if (fields.size() < 3)
                 break;
             umap_attr_filters_regex& attrs = filters[fields.at(0)];
-            std::vector<std::regex>& values = attrs[fields.at(1)];
+            std::vector<umap_attr_regex>& values = attrs[fields.at(1)];
             for (unsigned int i = 2; i < fields.size(); ++i)
-                values.emplace_back(fields.at(i), std::regex::optimize);
+                values.push_back({
+                    .regex{fields.at(i), std::regex::optimize},
+                    .str{fields.at(i)}
+                });
         }
         f.close();
     }

--- a/src/util.hh
+++ b/src/util.hh
@@ -41,8 +41,13 @@ namespace util {
         return uset.find(value) != uset.end();
     }
 
+    typedef struct {
+        std::regex regex;
+        std::string str;
+    } umap_attr_regex;
+    
     typedef std::unordered_map<std::string, std::vector<std::string>> umap_attr_filters;
-    typedef std::unordered_map<std::string, std::vector<std::regex>> umap_attr_filters_regex;
+    typedef std::unordered_map<std::string, std::vector<umap_attr_regex>> umap_attr_filters_regex;
     typedef std::unordered_map<std::string, umap_attr_filters> umap_tag_filters;
     typedef std::unordered_map<std::string, umap_attr_filters_regex> umap_tag_filters_regex;
 

--- a/src/warcpreprocessor.cc
+++ b/src/warcpreprocessor.cc
@@ -6,7 +6,7 @@
 namespace warc2text {
     const std::unordered_set<std::string> WARCPreprocessor::removeExtensions = {".jpg", ".jpeg", ".gif", ".png", ".css", ".js", ".mp3", ".mp4", ".flv", ".wmv", ".gz", ".zip", ".rar" };
 
-    WARCPreprocessor::WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files, const std::string& pdf_warc_filename, const std::string& tagFiltersFile) :
+    WARCPreprocessor::WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files, const std::string& pdf_warc_filename, const std::string& tagFiltersFile, bool invert) :
         writer(outputFolder, output_files),
         totalRecords(0),
         textRecords(0),
@@ -15,7 +15,8 @@ namespace warc2text {
         textBytes(0),
         langBytes(0),
         tagFilters(),
-        pdf_warc_filename(pdf_warc_filename) {
+        pdf_warc_filename(pdf_warc_filename),
+        invert(invert) {
             if (!tagFiltersFile.empty())
                 util::readTagFiltersRegex(tagFiltersFile, tagFilters);
         }
@@ -78,7 +79,7 @@ namespace warc2text {
             totalBytes += record.getPayload().size();
 
             int clean_retval = record.cleanPayload(tagFilters);
-            if (clean_retval == util::FILTERED_DOCUMENT_ERROR) {
+            if ((clean_retval == util::FILTERED_DOCUMENT_ERROR) != invert) {
                 BOOST_LOG_TRIVIAL(info) << "Record " << record.getURL() << " discarded due to tag filters";
                 continue;
             } else if (clean_retval == util::HTML_PARSING_ERROR) {

--- a/src/warcpreprocessor.hh
+++ b/src/warcpreprocessor.hh
@@ -35,9 +35,11 @@ namespace warc2text {
 
             static const std::unordered_set<std::string> removeExtensions;
             static bool URLfilter(const std::string& url);
+            std::string pdf_warc_filename;
+            bool invert;
 
         public:
-            explicit WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files = {}, const std::string& pdf_warc_filename = "", const std::string& tagFiltersFile = "");
+            explicit WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files = {}, const std::string& pdf_warc_filename = "", const std::string& tagFiltersFile = "", bool invert = false);
             void process(const std::string &filename);
             void printStatistics() const;
     };

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -16,8 +16,10 @@ struct Options {
     std::string files;
     std::string pdf_warc_filename;
     bool verbose{};
+    bool silent{};
     std::string output;
     std::string tag_filters_filename;
+    bool tag_filters_invert{};
 };
 
 void parseArgs(int argc, char *argv[], Options& out) {
@@ -29,8 +31,10 @@ void parseArgs(int argc, char *argv[], Options& out) {
         ("files,f", po::value(&out.files)->default_value("url,token"), "List of output files separated by commas. Default (mandatory files): 'url,text'. Optional: 'mime,html'")
         ("input,i", po::value(&out.warcs)->multitoken(), "Input WARC file name(s)")
         ("tag-filters", po::value(&out.tag_filters_filename), "Plain text file containing tag filters")
+        ("invert-tag-filters", po::bool_switch(&out.tag_filters_invert)->default_value(false), "Invert tag filter application")
         ("pdfpass", po::value(&out.pdf_warc_filename), "Write PDF records to WARC")
-        ("verbose,v", po::bool_switch(&out.verbose)->default_value(false), "Verbosity level");
+        ("verbose,v", po::bool_switch(&out.verbose)->default_value(false), "Verbosity level")
+        ("silent,s", po::bool_switch(&out.silent)->default_value(false));
 
     po::positional_options_description pd;
     pd.add("input", -1);
@@ -47,7 +51,9 @@ void parseArgs(int argc, char *argv[], Options& out) {
                 "                                  Optional values: \"mime,html\"\n"
                 " --tag-filters <filters_files>    File containing filters\n"
                 "                                  Format: \"html_tag <tab> tag_attr <tab> value\"\n"
+                " --invert-tag-filters             Only output records that got filtered\n"
                 " --pdfpass <output_warc>          Write PDF records to <output_warc>\n"
+                " -s                               Only output errors\n"
                 " -v                               Verbose output (print trace)\n\n";
         exit(1);
     }
@@ -63,7 +69,9 @@ int main(int argc, char *argv[]) {
     // configure logging
     boost::log::add_console_log(std::cerr, boost::log::keywords::format = "[%TimeStamp%] [\%Severity%] %Message%");
     boost::log::add_common_attributes();
-    auto verbosity_level = (options.verbose) ? boost::log::trivial::trace : boost::log::trivial::info;
+    auto verbosity_level = options.verbose ? boost::log::trivial::trace :
+                           options.silent  ? boost::log::trivial::warning :
+                                             boost::log::trivial::info;
     boost::log::core::get()->set_filter(boost::log::trivial::severity >= verbosity_level);
 
     // prepare list of output files
@@ -72,7 +80,7 @@ int main(int argc, char *argv[]) {
     std::unordered_set<std::string> output_files(files_list.begin(), files_list.end());
 
     std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-    WARCPreprocessor warcpproc(options.output, output_files, options.pdf_warc_filename, options.tag_filters_filename);
+    WARCPreprocessor warcpproc(options.output, output_files, options.pdf_warc_filename, options.tag_filters_filename, options.tag_filters_invert);
     for (const std::string& file : options.warcs){
         warcpproc.process(file);
     }


### PR DESCRIPTION
New command line options from @jelmervdl fork:
* `-s` to only output errors
* `--invert-tag-filters` to only output documents that have matches from tag filters

Also, new debug message showing the matched strings 