### PR TITLE
Allow comments in tag filter file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,18 @@ make
 warc2text -o <output_folder> [ -f <output_files> ] [ --pdfpass <output_warc> ] [ --tag-filters <filters_file> ] <warc_file>...
 ```
 * `--output`/`-o` output folder
-
 * `--files`/`-f` list of output files separated by commas (and without `.gz`); `text` and `url` are always written, while `mime` and `html` are optional
 * `--pdfpass` WARC file where PDF records will be stored
-* `--tag-filters` file containig filters that to eliminate some documents
-  
-  Filter format is the following: `tag <tab> attribute <tab> value ...`
+* `--tag-filters` file containing filters that to eliminate some documents
+* `--invert-tag-filters` output only documents that match the filter
+* `--verbose`/`-v` print progress and filtering information
+* `--silent`/`-s` print only warnings and errors
+
+  Filter format is the following: `tag <tab> attribute <tab> regexp`
   
   For example, `meta <tab> name <tab> translation-stats` will remove documents that contain `<meta name="translation-stats" ... >`
 
+  Lines beginning with `#` and empty lines are ignored. Any invalid filter will raise a warning message, but will not prevent other filters from being read.
 
 ## Included dependencies
 HTML Tokenizer by [c-smile](https://www.codeproject.com/Articles/14076/Fast-and-Compact-HTML-XML-Scanner-Tokenizer)

--- a/debug-filters.sh
+++ b/debug-filters.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Script to help with figuring out what your --tagfilters filters are doing.
+#
+# Usage: debug-filters.sh tagfilters.txt *.warc.gz
+# This will process the warcs with the tag filters, and save all *filtered*
+# documents as html in the current folder. Each HTML file will have a header
+# with the URL and the filters that caught it.
+#
+# Note: This script needs at least Bash 4.0 (Apple users beware!)
+#
+set -euo pipefail
+
+FILTERLIST=$1
+shift
+
+OUTPUT=$(mktemp -d ./textXXXX)
+
+${WARC2TEXT:-warc2text} \
+	-o $OUTPUT \
+	-f html,url \
+	--verbose \
+	--invert-tag-filters \
+	--tag-filters $FILTERLIST \
+	$@ \
+	>&${OUTPUT}/log.txt
+
+##
+# Parse the logs to figure out which urls got filtered for what reason
+##
+
+declare -A MATCHES
+
+URL_PATTERN="Processing HTML document (.+)$"
+FILTER_PATTERN="Tag filter ([a-z]+\[.+\]) matched"
+NEWLINE=$'\n'
+
+while read line; do
+	if [[ $line =~ $URL_PATTERN ]]; then
+		URL=${BASH_REMATCH[1]}
+	elif [[ $line =~ $FILTER_PATTERN ]]; then
+		MATCHES[$URL]+="${BASH_REMATCH[1]}$NEWLINE"
+	fi
+done < $OUTPUT/log.txt
+
+# for URL in "${!MATCHES[@]}"; do
+# 	echo "URL: $URL"
+# 	echo "FILTERS: ${MATCHES[$URL]}"
+# done
+
+##
+# Extract the html and url files for each language into separate html files.
+##
+
+N=0
+
+for LANG_PATH in $OUTPUT/*/; do
+	paste -d$'\t' \
+		<(gzip -cd < $LANG_PATH/url.gz) \
+		<(gzip -cd < $LANG_PATH/html.gz) \
+	| while IFS=$'\t' read URL HTML_ENCODED; do
+		N=$((N + 1))
+		FILE=$(printf "%06d.html" $N)
+		printf "<!--\nLANG: %s\nURL: %s\nFILTERS: %s-->\n" $(basename "$LANG_PATH") "$URL" "${MATCHES[$URL]:-}" > $FILE
+		base64 -d <<< "$HTML_ENCODED" >> $FILE
+	done
+done

--- a/src/util.cc
+++ b/src/util.cc
@@ -86,22 +86,6 @@ namespace util {
         preprocess::base64_decode(base64, output);
     }
 
-    void readTagFilters(const std::string& filename, umap_tag_filters& filters) {
-        std::ifstream f(filename);
-        std::string line;
-        std::vector<std::string> fields;
-        while (std::getline(f, line)) {
-            fields.clear();
-            boost::algorithm::split(fields, line, [](char c){return c == '\t';});
-            if (fields.size() < 3)
-                break;
-            umap_attr_filters& attrs = filters[fields.at(0)];
-            std::vector<std::string>& values = attrs[fields.at(1)];
-            for (unsigned int i = 2; i < fields.size(); ++i)
-                values.emplace_back(fields.at(i));
-        }
-        f.close();
-    }
 
     void readTagFiltersRegex(const std::string& filename, umap_tag_filters_regex& filters) {
         std::ifstream f(filename);

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,4 +1,5 @@
 #include "util.hh"
+#include <cstring>
 #include <fstream>
 #include <algorithm>
 #include <vector>
@@ -87,12 +88,25 @@ namespace util {
         preprocess::base64_decode(base64, output);
     }
 
+    bool isEmpty(const std::string &str) {
+        for (size_t i = 0; i < str.size(); ++i)
+            if (!std::isspace(str[i]))
+                return false;
+        return true;
+    }
+
+    bool startsWith(const std::string &str, const std::string &prefix) {
+        return str.size() >= prefix.size()
+            && std::strncmp(str.c_str(), prefix.c_str(), prefix.size()) == 0;
+    }
 
     void readTagFiltersRegex(const std::string& filename, umap_tag_filters_regex& filters) {
         std::ifstream f(filename);
         std::string line;
         std::vector<std::string> fields;
         for (size_t line_i=1; std::getline(f, line); ++line_i) {
+            if (isEmpty(line) || startsWith(line, "#"))
+                continue;
             fields.clear();
             boost::algorithm::split(fields, line, [](char c){return c == '\t';});    
             if (fields.size() < 3) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -8,6 +8,7 @@
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/locale.hpp>
+#include <boost/log/trivial.hpp>
 #include <uchardet/uchardet.h>
 #include "preprocess/base64.hh"
 
@@ -91,11 +92,13 @@ namespace util {
         std::ifstream f(filename);
         std::string line;
         std::vector<std::string> fields;
-        while (std::getline(f, line)) {
+        for (size_t line_i=1; std::getline(f, line); ++line_i) {
             fields.clear();
-            boost::algorithm::split(fields, line, [](char c){return c == '\t';});
-            if (fields.size() < 3)
-                break;
+            boost::algorithm::split(fields, line, [](char c){return c == '\t';});    
+            if (fields.size() < 3) {
+                BOOST_LOG_TRIVIAL(warning) << "Could not parse tag filter at line " << line_i << " of " << filename;
+                continue;
+            }
             umap_attr_filters_regex& attrs = filters[fields.at(0)];
             std::vector<umap_attr_regex>& values = attrs[fields.at(1)];
             for (unsigned int i = 2; i < fields.size(); ++i)

--- a/src/util.hh
+++ b/src/util.hh
@@ -46,12 +46,9 @@ namespace util {
         std::string str;
     } umap_attr_regex;
     
-    typedef std::unordered_map<std::string, std::vector<std::string>> umap_attr_filters;
     typedef std::unordered_map<std::string, std::vector<umap_attr_regex>> umap_attr_filters_regex;
-    typedef std::unordered_map<std::string, umap_attr_filters> umap_tag_filters;
     typedef std::unordered_map<std::string, umap_attr_filters_regex> umap_tag_filters_regex;
 
-    void readTagFilters(const std::string& filename, umap_tag_filters& filters);
     void readTagFiltersRegex(const std::string& filename, umap_tag_filters_regex& filters);
 
     bool createDirectories(const std::string& path);


### PR DESCRIPTION
I've been annotating Minas' tag filter file to add notes about what rules filter what and why they're in there. It's probably easy if the file with annotations can be used as-is, and doesn't need to be processed through `sed` or something.

This merge request also contains some more noisy error reporting for when an unparseable line is encountered. Previously this would stop the parsing of the filter list silently. Now it will raise a warning but continue with the next line.

Oh and I removed the dead code of readTagFilters.