### PR TITLE
Fix compilation issue with gcc.

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -116,8 +116,8 @@ namespace util {
             umap_attr_filters_regex& attrs = filters[fields.at(0)];
             std::vector<umap_attr_regex>& values = attrs[fields.at(1)];
             for (unsigned int i = 2; i < fields.size(); ++i)
-                values.push_back({
-                    .regex{fields.at(i), std::regex::optimize},
+                values.emplace_back(umap_attr_regex{
+                    .regex{std::regex(fields.at(i), std::regex::optimize)},
                     .str{fields.at(i)}
                 });
         }

--- a/src/util.hh
+++ b/src/util.hh
@@ -45,7 +45,7 @@ namespace util {
         std::regex regex;
         std::string str;
     } umap_attr_regex;
-    
+
     typedef std::unordered_map<std::string, std::vector<umap_attr_regex>> umap_attr_filters_regex;
     typedef std::unordered_map<std::string, umap_attr_filters_regex> umap_tag_filters_regex;
 


### PR DESCRIPTION
Sorry about this.

Clang was happy with the brace initializer for regex, but gcc/9 on CSD3 wasn't.