### PR TITLE
Replace zip extraction

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(warc2text_lib
     bilangwriter.cc
     xh_scanner.cc
     entities.cc
+    zipreader.cc
 )
 
 

--- a/src/html.cc
+++ b/src/html.cc
@@ -62,6 +62,8 @@ namespace warc2text {
                     tag = util::toLowerCopy(sc.get_tag_name());
                     // found block tag: previous block has ended
                     if (html::isBlockTag(tag)) addNewLine(plaintext);
+                    // found void tag, like <img> or <embed>
+                    if (html::isVoidTag(tag)) addSpace(plaintext);
                     break;
                 case markup::scanner::TT_WORD:
                     // if the tag is in noText list, don't save the text

--- a/src/record.cc
+++ b/src/record.cc
@@ -144,7 +144,7 @@ namespace warc2text {
                 try {
                     unzipped_payload += file.read();
                 } catch (util::ZipReadError &e) {
-                    BOOST_LOG_TRIVIAL(error) << "Could not read file " << file.name() << " from zip archive: " << e.what();
+                    BOOST_LOG_TRIVIAL(trace) << "Could not read file " << file.name() << " from zip archive: " << e.what();
                 }
             }
         }

--- a/src/record.cc
+++ b/src/record.cc
@@ -10,7 +10,6 @@
 #include "zipreader.hh"
 #include <boost/log/trivial.hpp>
 #include <boost/algorithm/string/predicate.hpp>
-#include <iostream>
 
 namespace warc2text {
     const std::unordered_set<std::string> Record::textContentTypes = {"text/plain", "text/html", "application/xml", "text/vnd.wap.wml", "application/atom+xml", "application/opensearchdescription+xml", "application/rss+xml", "application/xhtml+xml"};

--- a/src/record.cc
+++ b/src/record.cc
@@ -139,10 +139,16 @@ namespace warc2text {
         
         util::ZipReader zip(payload);
 
-        for (auto file : zip)
-            if (std::regex_match(file.name(), zip_types.at(content_type)))
-                unzipped_payload += file.read();
-
+        for (auto file : zip) {
+            if (std::regex_match(file.name(), zip_types.at(content_type))) {
+                try {
+                    unzipped_payload += file.read();
+                } catch (util::ZipReadError &e) {
+                    BOOST_LOG_TRIVIAL(error) << "Could not read file " << file.name() << " from zip archive: " << e.what();
+                }
+            }
+        }
+        
         return unzipped_payload;
     }
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,5 +1,4 @@
 #include "util.hh"
-#include <cstring>
 #include <fstream>
 #include <algorithm>
 #include <vector>
@@ -8,6 +7,8 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/classification.hpp>
 #include <boost/locale.hpp>
 #include <boost/log/trivial.hpp>
 #include <uchardet/uchardet.h>
@@ -88,24 +89,12 @@ namespace util {
         preprocess::base64_decode(base64, output);
     }
 
-    bool isEmpty(const std::string &str) {
-        for (size_t i = 0; i < str.size(); ++i)
-            if (!std::isspace(str[i]))
-                return false;
-        return true;
-    }
-
-    bool startsWith(const std::string &str, const std::string &prefix) {
-        return str.size() >= prefix.size()
-            && std::strncmp(str.c_str(), prefix.c_str(), prefix.size()) == 0;
-    }
-
     void readTagFiltersRegex(const std::string& filename, umap_tag_filters_regex& filters) {
         std::ifstream f(filename);
         std::string line;
         std::vector<std::string> fields;
         for (size_t line_i=1; std::getline(f, line); ++line_i) {
-            if (isEmpty(line) || startsWith(line, "#"))
+            if (boost::algorithm::all(line, boost::algorithm::is_space()) || boost::algorithm::starts_with(line, "#"))
                 continue;
             fields.clear();
             boost::algorithm::split(fields, line, [](char c){return c == '\t';});    

--- a/src/util.hh
+++ b/src/util.hh
@@ -69,7 +69,9 @@ namespace html {
         "blockquote", "body", "br", "details", "dialog", "dd", "div", "dl", "dt",
         "fieldset", "figcaption", "figure", "footer", "form", "h1", "h2", "h3", "h4",
         "h5", "h6", "head", "header", "hgroup", "html", "hr", "li", "main", "nav",
-        "ol", "p", "pre", "section", "table", "td", "th", "title", "tr", "ul"} );
+        "ol", "p", "pre", "section", "table", "td", "th", "title", "tr", "ul",
+        // ODT tags
+        "text:p"} );
 
     // inline html elements
     const std::unordered_set<std::string> inlineTags ( {"a", "abbr", "acronym", "audio",
@@ -78,7 +80,9 @@ namespace html {
         "ins", "kdb", "label", "map", "mark", "meter", "noscript", "object",
         "output", "picture", "progress", "q", "ruby", "s", "samp", "script",
         "select", "slot", "small", "span", "strong", "sub", "sup", "svg", "template",
-        "textarea", "time", "u", "tt", "var", "video", "wbr" });
+        "textarea", "time", "u", "tt", "var", "video", "wbr",
+        // ODT tags
+        "text:span" });
 
     inline bool isBlockTag(const std::string& tag) { return util::uset_contains(blockTags, tag); }
     inline bool isInlineTag(const std::string& tag) { return util::uset_contains(inlineTags, tag); }

--- a/src/util.hh
+++ b/src/util.hh
@@ -61,7 +61,12 @@ namespace html {
     // html elements that are self-closing (no content)
     const std::unordered_set<std::string> voidTags ( {"!doctype", "area", "base", "br",
         "col", "command", "embed", "hr", "img", "input", "keygen", "link", "meta",
-        "param", "source", "track", "wbr"} );
+        "param", "source", "track", "wbr",
+        // ODP tags
+        "text:s", // represents a space
+        // MS Word tags
+        "w:s"
+    } );
 
     // block html elements
     // br is technically inline, but for the purposes of text extraction is should be treated as block
@@ -73,7 +78,10 @@ namespace html {
         // ODT tags
         "text:p",
         // MS Word tags
-        "w:p"} );
+        "w:p",
+        // MS Powerpoint
+        "a:p"
+    } );
 
     // inline html elements
     const std::unordered_set<std::string> inlineTags ( {"a", "abbr", "acronym", "audio",
@@ -86,7 +94,8 @@ namespace html {
         // ODT tags
         "text:span",
         // MS Word tags
-        "w:s", "w:t", "w:r"});
+        "w:t", "w:r"
+    });
 
     inline bool isBlockTag(const std::string& tag) { return util::uset_contains(blockTags, tag); }
     inline bool isInlineTag(const std::string& tag) { return util::uset_contains(inlineTags, tag); }

--- a/src/util.hh
+++ b/src/util.hh
@@ -71,7 +71,9 @@ namespace html {
         "h5", "h6", "head", "header", "hgroup", "html", "hr", "li", "main", "nav",
         "ol", "p", "pre", "section", "table", "td", "th", "title", "tr", "ul",
         // ODT tags
-        "text:p"} );
+        "text:p",
+        // MS Word tags
+        "w:p"} );
 
     // inline html elements
     const std::unordered_set<std::string> inlineTags ( {"a", "abbr", "acronym", "audio",
@@ -82,7 +84,9 @@ namespace html {
         "select", "slot", "small", "span", "strong", "sub", "sup", "svg", "template",
         "textarea", "time", "u", "tt", "var", "video", "wbr",
         // ODT tags
-        "text:span" });
+        "text:span",
+        // MS Word tags
+        "w:s", "w:t", "w:r"});
 
     inline bool isBlockTag(const std::string& tag) { return util::uset_contains(blockTags, tag); }
     inline bool isInlineTag(const std::string& tag) { return util::uset_contains(inlineTags, tag); }

--- a/src/zipreader.cc
+++ b/src/zipreader.cc
@@ -1,0 +1,71 @@
+#include "zipreader.hh"
+#include <cassert>
+
+namespace util {
+
+ZipReader::ZipReader(const std::string &payload)
+: src_(nullptr, &zip_source_free), archive_() {
+    zip_error_t error{};
+    src_.reset(zip_source_buffer_create(const_cast<void*>(static_cast<const void*>(payload.data())), payload.size(), 0, &error));
+
+    if (!src_)
+        throw ZipReadError(&error);
+
+    zip_source_keep(src_.get());
+
+    archive_.reset(zip_open_from_source(src_.get(), 0, &error), zip_discard);
+
+    if (!archive_)
+        throw ZipReadError(&error);
+}
+
+size_t ZipReader::size() const {
+    zip_int64_t num_entries = zip_get_num_entries(archive_.get(), 0);
+    return num_entries;
+}
+
+ZipEntry::ZipEntry(std::shared_ptr<zip_t> archive, size_t index)
+: archive_(archive), index_(index) {
+    //
+}
+
+size_t ZipEntry::index() const {
+    return index_;
+}
+
+std::string ZipEntry::name() const {
+    const char *name = zip_get_name(archive_.get(), index_, 0);
+    return std::string(name);
+}
+
+size_t ZipEntry::size() const {
+    zip_stat_t st;
+    zip_stat_init(&st);
+    zip_stat_index(archive_.get(), index_, 0, &st);
+    return st.size;
+}
+
+std::string ZipEntry::read(std::string &&buffer) const {
+    buffer.resize(size());
+    
+    std::unique_ptr<zip_file_t, decltype(&zip_fclose)> fh(zip_fopen_index(archive_.get(), index_, 0), &zip_fclose);
+    if (!fh)
+        throw ZipReadError(zip_get_error(archive_.get()));
+
+    for (size_t read = 0; read < buffer.size();) {
+        auto len = zip_fread(fh.get(), &buffer[0] + read, buffer.size() - read);
+
+        if (len == -1)
+            throw ZipReadError(zip_get_error(archive_.get()));
+
+        read += len;
+    }
+    
+    return std::move(buffer);
+}
+
+std::string ZipEntry::read() const {
+    return read(std::string());
+}
+
+} // end namespace

--- a/src/zipreader.cc
+++ b/src/zipreader.cc
@@ -6,15 +6,14 @@ namespace util {
 ZipReader::ZipReader(const std::string &payload)
 : src_(nullptr, &zip_source_free), archive_() {
     zip_error_t error{};
-    src_.reset(zip_source_buffer_create(const_cast<void*>(static_cast<const void*>(payload.data())), payload.size(), 0, &error));
 
+    src_.reset(zip_source_buffer_create(const_cast<void*>(static_cast<const void*>(payload.data())), payload.size(), 0, &error));
     if (!src_)
         throw ZipReadError(&error);
 
     zip_source_keep(src_.get());
 
     archive_.reset(zip_open_from_source(src_.get(), 0, &error), zip_discard);
-
     if (!archive_)
         throw ZipReadError(&error);
 }

--- a/src/zipreader.hh
+++ b/src/zipreader.hh
@@ -1,0 +1,119 @@
+#include <string>
+#include <memory>
+#include <zip.h>
+
+namespace util {
+
+class ZipReadError : public std::runtime_error {
+public:
+    ZipReadError(std::string const &error) : runtime_error(error) {
+        //
+    }
+
+    ZipReadError(zip_error_t *error) : runtime_error(zip_error_strerror(error)) {
+        //
+    }
+};
+
+class ZipEntry {
+private:
+    std::shared_ptr<zip_t> archive_;
+    size_t index_;
+public:
+    ZipEntry(std::shared_ptr<zip_t> archive, size_t index);
+
+    size_t index() const;
+    std::string name() const;
+    size_t size() const;
+    std::string read(std::string &&buffer) const;
+    std::string read() const;
+
+    friend bool operator==(const ZipEntry& a, const ZipEntry& b) {
+        return a.archive_ == b.archive_ && a.index_ == b.index_;
+    };
+    
+    friend bool operator!=(const ZipEntry& a, const ZipEntry& b) {
+        return a.archive_ != b.archive_ || a.index_ != b.index_;
+    };
+
+    friend class ZipEntryIterator;
+};
+
+class ZipEntryIterator {
+private:
+    ZipEntry entry_;
+public:
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type   = int;
+    using value_type        = ZipEntry;
+    using pointer           = ZipEntry const *;
+    using reference         = ZipEntry const &;
+
+    ZipEntryIterator(std::shared_ptr<zip_t> archive, size_t index)\
+    : entry_(archive, index) {
+        //
+    }
+
+    reference operator*() const {
+        return entry_;
+    }
+
+    pointer operator->() const {
+        return &entry_;
+    }
+
+    // Prefix increment
+    ZipEntryIterator& operator++() {
+        entry_.index_++;
+        return *this;
+    }
+
+    // Postfix increment
+    ZipEntryIterator operator++(int) {
+        ZipEntryIterator tmp = *this;
+        ++(*this);
+        return tmp;
+    }
+
+    friend bool operator==(const ZipEntryIterator& a, const ZipEntryIterator& b) {
+        return a.entry_ == b.entry_;
+    };
+    
+    friend bool operator!=(const ZipEntryIterator& a, const ZipEntryIterator& b) {
+        return a.entry_ != b.entry_;
+    };
+};
+
+/**
+ * Class to iterate over files in an in-memory zip archive.
+ * 
+ * Example:
+ * 
+ *   ZipReader reader(buffer);
+ *   for (auto file : reader)
+ *     if (file.name() == "something.txt")
+ *       std::cerr << file.read();
+ * 
+ */
+class ZipReader {
+private:
+    std::unique_ptr<zip_source_t, decltype(&zip_source_free)> src_;
+    std::shared_ptr<zip_t> archive_;
+
+public:
+    typedef ZipEntryIterator const_iterator;
+
+    ZipReader(const std::string &payload);
+
+    size_t size() const;
+
+    const_iterator begin() const {
+        return ZipEntryIterator(archive_, 0);
+    }
+    
+    const_iterator end() const {
+        return ZipEntryIterator(archive_, size());
+    }
+};
+
+} // end namespace


### PR DESCRIPTION
I've replaced the zip extraction logic with some more C++-ish code that doesn't crash or leak on the test files I've used.

(I've also taken this opportunity to replace two string functions that I previously pushed with functions that are already available in boost::algorithm.)

Zip reading is now working better with this patch. However, the output of the extracted odts isn't great. I've attached a warc file with two odts. One fails in the HTML parser, the other makes it through but has no line breaks at all in the text output.

Maybe some simple changes to the html parser will make it more compatible with odts. I haven't looked into that yet.
[zip.warc.gz](https://github.com/bitextor/warc2text/files/5836745/zip.warc.gz)

Edit: Also attaching a test warc with a couple of office document formats: [burns.warc.gz](https://github.com/bitextor/warc2text/files/5842039/burns.warc.gz) All xml-based ones from this test are now extracted properly. rtf, doc, ppt, pdf are not being extracted, as expected. The Apple Pages document is a zip file as well, but the contents are not xml files but protobuf streams, so we can't really do much for those.
