### PR TITLE
Use CLD2 extended detection method to detect multiple languages in a single document 

### DIFF
--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -92,17 +92,16 @@ namespace warc2text{
         if (gzhtml != nullptr) gzhtml->writeLine(b64html);
     }
 
-
-    void BilangWriter::write(const Record& record) {
-        if (record.containsMultipleLanguages()) {
-            std::string lang;
-            std::string base64text;
-            std::string lang_text;
-            std::string base64html;
+    void BilangWriter::write(const Record& record, bool multilang) {
+        std::string base64text;
+        std::string base64html;
+        if (multilang) {
 
             if (output_files.count("html") == 1)
                 util::encodeBase64(record.getPayload(), base64html);
 
+            std::string lang;
+            std::string lang_text;
             for (unsigned int i = 0; i < 3; ++i) {
                 record.getLanguageByIndex(i, lang);
                 if (lang.empty()) continue;
@@ -110,16 +109,13 @@ namespace warc2text{
                 util::encodeBase64(lang_text, base64text);
                 this->write(lang, base64text, record.getURL(), record.getHTTPcontentType(), base64html);
             }
-        }
-        else {
-            std::string lang = record.getLanguage();
-            std::string base64text;
+        } else {
             util::encodeBase64(record.getPlainText(), base64text);
-            std::string base64html;
             if (output_files.count("html") == 1)
                 util::encodeBase64(record.getPayload(), base64html);
-            this->write(lang, base64text, record.getURL(), record.getHTTPcontentType(), base64html);
+            this->write(record.getLanguage(), base64text, record.getURL(), record.getHTTPcontentType(), base64html);
         }
     }
+
 }
 

--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -104,9 +104,10 @@ namespace warc2text{
                 util::encodeBase64(record.getPayload(), base64html);
 
             for (unsigned int i = 0; i < 3; ++i) {
-                record.getTextByLanguageIndex(i, lang_text);
                 record.getLanguageByIndex(i, lang);
-                util::encodeBase64(record.getPlainText(), base64text);
+                if (lang.empty()) continue;
+                record.getTextByLanguageIndex(i, lang_text);
+                util::encodeBase64(lang_text, base64text);
                 this->write(lang, base64text, record.getURL(), record.getHTTPcontentType(), base64html);
             }
         }

--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -60,40 +60,64 @@ namespace warc2text{
         this->compress("\n", 1, Z_NO_FLUSH);
     }
 
+    void GzipWriter::writeLine(const std::string& text) {
+        this->compress(text.c_str(), text.size(), Z_NO_FLUSH);
+        this->compress("\n", 1, Z_NO_FLUSH);
+    }
 
     bool GzipWriter::is_open(){
         return dest != nullptr;
     }
 
-    void BilangWriter::write(const Record& record) {
-        const std::string* lang = &record.getLanguage();
-        GzipWriter* url = &url_files[*lang];
-        GzipWriter* text = &text_files[*lang];
-        GzipWriter* mime = nullptr;
-        GzipWriter* html = nullptr;
-        if (output_files.count("mime") == 1) mime = &(mime_files[*lang]);
-        if (output_files.count("html") == 1) html = &(html_files[*lang]);
-        if (!url->is_open()) {
+    void BilangWriter::write(const std::string& lang, const std::string& b64text, const std::string& url, const std::string& mime, const std::string& b64html) {
+        GzipWriter* gzurl = &url_files[lang];
+        GzipWriter* gztext = &text_files[lang];
+        GzipWriter* gzmime = nullptr;
+        GzipWriter* gzhtml = nullptr;
+        if (output_files.count("mime") == 1) gzmime = &(mime_files[lang]);
+        if (output_files.count("html") == 1) gzhtml = &(html_files[lang]);
+        if (!gzurl->is_open()) {
             // if one file does not exist, the rest shouldn't either
-            std::string path = folder + "/" + *lang;
+            std::string path = folder + "/" + lang;
             util::createDirectories(path);
-            url->open(path + "/url.gz");
-            text->open(path + "/text.gz");
-            if (mime != nullptr) mime->open(path + "/mime.gz");
-            if (html != nullptr) html->open(path + "/html.gz");
+            gzurl->open(path + "/url.gz");
+            gztext->open(path + "/text.gz");
+            if (gzmime != nullptr) gzmime->open(path + "/mime.gz");
+            if (gzhtml != nullptr) gzhtml->open(path + "/html.gz");
         }
 
-        url->writeLine(record.getURL().data(), record.getURL().size());
-        std::string base64text;
-        util::encodeBase64(record.getPlainText(), base64text);
-        text->writeLine(base64text.data(), base64text.size());
+        gzurl->writeLine(url);
+        gztext->writeLine(b64text);
+        if (gzmime != nullptr) gzmime->writeLine(mime);
+        if (gzhtml != nullptr) gzhtml->writeLine(b64html);
+    }
 
-        if (mime != nullptr)
-            mime->writeLine(record.getHTTPcontentType().data(), record.getHTTPcontentType().size());
-        if (html != nullptr) {
+
+    void BilangWriter::write(const Record& record) {
+        if (record.containsMultipleLanguages()) {
+            std::string lang;
+            std::string base64text;
+            std::string lang_text;
             std::string base64html;
-            util::encodeBase64(record.getPayload(), base64html);
-            html->writeLine(base64html.data(), base64html.size());
+
+            if (output_files.count("html") == 1)
+                util::encodeBase64(record.getPayload(), base64html);
+
+            for (unsigned int i = 0; i < 3; ++i) {
+                record.getTextByLanguageIndex(i, lang_text);
+                record.getLanguageByIndex(i, lang);
+                util::encodeBase64(record.getPlainText(), base64text);
+                this->write(lang, base64text, record.getURL(), record.getHTTPcontentType(), base64html);
+            }
+        }
+        else {
+            std::string lang = record.getLanguage();
+            std::string base64text;
+            util::encodeBase64(record.getPlainText(), base64text);
+            std::string base64html;
+            if (output_files.count("html") == 1)
+                util::encodeBase64(record.getPayload(), base64html);
+            this->write(lang, base64text, record.getURL(), record.getHTTPcontentType(), base64html);
         }
     }
 }

--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -100,14 +100,10 @@ namespace warc2text{
             if (output_files.count("html") == 1)
                 util::encodeBase64(record.getPayload(), base64html);
 
-            std::string lang;
-            std::string lang_text;
-            for (unsigned int i = 0; i < 3; ++i) {
-                record.getLanguageByIndex(i, lang);
-                if (lang.empty()) continue;
-                record.getTextByLanguageIndex(i, lang_text);
-                util::encodeBase64(lang_text, base64text);
-                this->write(lang, base64text, record.getURL(), record.getHTTPcontentType(), base64html);
+            for (auto it : record.getTextByLangs()) {
+                util::encodeBase64(it.second, base64text);
+                this->write(it.first, base64text, record.getURL(), record.getHTTPcontentType(), base64html);
+
             }
         } else {
             util::encodeBase64(record.getPlainText(), base64text);

--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -103,8 +103,8 @@ namespace warc2text{
             for (auto it : record.getTextByLangs()) {
                 util::encodeBase64(it.second, base64text);
                 this->write(it.first, base64text, record.getURL(), record.getHTTPcontentType(), base64html);
-
             }
+
         } else {
             util::encodeBase64(record.getPlainText(), base64text);
             if (output_files.count("html") == 1)

--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -100,7 +100,7 @@ namespace warc2text{
             if (output_files.count("html") == 1)
                 util::encodeBase64(record.getPayload(), base64html);
 
-            for (auto it : record.getTextByLangs()) {
+            for (const auto& it : record.getTextByLangs()) {
                 util::encodeBase64(it.second, base64text);
                 this->write(it.first, base64text, record.getURL(), record.getHTTPcontentType(), base64html);
             }

--- a/src/bilangwriter.hh
+++ b/src/bilangwriter.hh
@@ -22,6 +22,7 @@ namespace warc2text {
             void open(const std::string& filename);
             void write(const char* text, std::size_t size);
             void writeLine(const char* text, std::size_t size);
+            void writeLine(const std::string& text);
             bool is_open();
             static const std::size_t BUFFER_SIZE = 4096;
     };
@@ -34,6 +35,8 @@ namespace warc2text {
             std::unordered_map<std::string, GzipWriter> text_files;
             std::unordered_map<std::string, GzipWriter> html_files;
             std::unordered_set<std::string> output_files;
+
+            void write(const std::string& lang, const std::string& b64text, const std::string& url, const std::string& mime, const std::string& b64html);
 
         public:
             explicit BilangWriter(const std::string& folder) :

--- a/src/bilangwriter.hh
+++ b/src/bilangwriter.hh
@@ -57,7 +57,8 @@ namespace warc2text {
                 output_files(output_files)
             {};
 
-            void write(const Record& record);
+            void write(const Record& record, bool multilang = false);
+
     };
 
 

--- a/src/lang.cc
+++ b/src/lang.cc
@@ -30,8 +30,10 @@ namespace warc2text {
         if (results.size() == 1) return reliable;
 
         for (const CLD2::ResultChunk& chunk : chunks) {
-            int index = chunk.lang1 == static_cast<CLD2::Language>(top3[0]) ? 0 :
-                        chunk.lang1 == static_cast<CLD2::Language>(top3[1]) ? 1 : 2;
+            int index = static_cast<CLD2::Language>(chunk.lang1) == top3[0] ? 0 :
+                        static_cast<CLD2::Language>(chunk.lang1) == top3[1] ? 1 :
+                        static_cast<CLD2::Language>(chunk.lang1) == top3[2] ? 2 : 3;
+            if (index >= results.size()) continue;
             results[index].chunks.emplace_back(chunk.offset, chunk.bytes);
         }
 

--- a/src/lang.cc
+++ b/src/lang.cc
@@ -4,8 +4,8 @@ namespace warc2text {
     // hint = {content language code(s), tld, original encoding, CLD2::Language}
     const CLD2::CLDHints NO_HINT = {nullptr, nullptr, CLD2::UNKNOWN_ENCODING, CLD2::UNKNOWN_LANGUAGE};
 
-    bool detectLanguage(const std::string& text, std::vector<LanguageDetection>& results){
-        CLD2::Language top3[3] = {CLD2::UNKNOWN_LANGUAGE, CLD2::UNKNOWN_LANGUAGE, CLD2::UNKNOWN_LANGUAGE};
+    bool detectLanguage(const std::string& text, std::unordered_map<std::string, std::string>& text_by_lang){
+        CLD2::Language langs[3] = {CLD2::UNKNOWN_LANGUAGE, CLD2::UNKNOWN_LANGUAGE, CLD2::UNKNOWN_LANGUAGE};
         int percents[3] = {0,0,0};
         double scores[3] = {0.0, 0.0, 0.0};
 
@@ -15,24 +15,36 @@ namespace warc2text {
 
         CLD2::ResultChunkVector chunks;
 
-        CLD2::ExtDetectLanguageSummaryCheckUTF8(text.data(), text.size(), true, &NO_HINT, 0, &top3[0], &percents[0], &scores[0], &chunks, &text_bytes, &reliable, &valid_prefix_bytes);
+        CLD2::ExtDetectLanguageSummaryCheckUTF8(text.data(), text.size(), true, &NO_HINT, 0, &langs[0], &percents[0], &scores[0], &chunks, &text_bytes, &reliable, &valid_prefix_bytes);
 
-        results.clear();
+        text_by_lang.clear();
 
         if (not reliable) return reliable;
 
-        results.emplace_back(CLD2::LanguageCode(top3[0]), percents[0], scores[0]);
-        if (top3[1] != CLD2::UNKNOWN_LANGUAGE and percents[1] > 0)
-            results.emplace_back(CLD2::LanguageCode(top3[1]), percents[1], scores[1]);
-        if (top3[2] != CLD2::UNKNOWN_LANGUAGE and percents[2] > 0)
-            results.emplace_back(CLD2::LanguageCode(top3[2]), percents[2], scores[2]);
+        std::string* top1 = nullptr;
+        std::string* top2 = nullptr;
+        std::string* top3 = nullptr;
+
+        if (langs[0] != CLD2::UNKNOWN_LANGUAGE and percents[0] > 0) {
+            top1 = &text_by_lang[CLD2::LanguageCode(langs[0])];
+            top1->reserve(text.size() * (percents[0] + 1));
+        }
+
+        if (langs[1] != CLD2::UNKNOWN_LANGUAGE and percents[1] > 0) {
+            top2 = &text_by_lang[CLD2::LanguageCode(langs[1])];
+            top2->reserve(text.size() * (percents[1] + 1));
+        }
+        if (langs[2] != CLD2::UNKNOWN_LANGUAGE and percents[2] > 0) {
+            top3 = &text_by_lang[CLD2::LanguageCode(langs[2])];
+            top3->reserve(text.size() * (percents[2] + 1));
+        }
 
         for (const CLD2::ResultChunk& chunk : chunks) {
-            int index = static_cast<CLD2::Language>(chunk.lang1) == top3[0] ? 0 :
-                        static_cast<CLD2::Language>(chunk.lang1) == top3[1] ? 1 :
-                        static_cast<CLD2::Language>(chunk.lang1) == top3[2] ? 2 : 3;
-            if (index >= results.size()) continue;
-            results[index].chunks.emplace_back(chunk.offset, chunk.bytes);
+            std::string* ref = static_cast<CLD2::Language>(chunk.lang1) == langs[0] ? top1 :
+                        static_cast<CLD2::Language>(chunk.lang1) == langs[1] ? top2 :
+                        static_cast<CLD2::Language>(chunk.lang1) == langs[2] ? top3 : nullptr;
+            if (ref == nullptr) continue;
+            ref->append(text, chunk.offset, chunk.bytes);
         }
 
         return reliable;

--- a/src/lang.cc
+++ b/src/lang.cc
@@ -34,6 +34,7 @@ namespace warc2text {
             top2 = &text_by_lang[CLD2::LanguageCode(langs[1])];
             top2->reserve(text.size() * (percents[1] + 1));
         }
+
         if (langs[2] != CLD2::UNKNOWN_LANGUAGE and percents[2] > 0) {
             top3 = &text_by_lang[CLD2::LanguageCode(langs[2])];
             top3->reserve(text.size() * (percents[2] + 1));
@@ -46,6 +47,15 @@ namespace warc2text {
             if (ref == nullptr) continue;
             ref->append(text, chunk.offset, chunk.bytes);
         }
+
+        // remove empty texts from text_by_lang
+        // apparently it is possible that the reported percentage is > 0, but the language does not appear in chunks
+        for (auto it = text_by_lang.cbegin(); it != text_by_lang.cend(); ){
+            if (it->second.size() == 0) text_by_lang.erase(it++);
+            else ++it;
+        }
+
+        // TODO: do something with the scores?
 
         return reliable;
     }

--- a/src/lang.cc
+++ b/src/lang.cc
@@ -22,12 +22,10 @@ namespace warc2text {
         if (not reliable) return reliable;
 
         results.emplace_back(CLD2::LanguageCode(top3[0]), percents[0], scores[0]);
-        if (percents[1] > 0)
+        if (top3[1] != CLD2::UNKNOWN_LANGUAGE and percents[1] > 0)
             results.emplace_back(CLD2::LanguageCode(top3[1]), percents[1], scores[1]);
-        if (percents[2] > 0)
+        if (top3[2] != CLD2::UNKNOWN_LANGUAGE and percents[2] > 0)
             results.emplace_back(CLD2::LanguageCode(top3[2]), percents[2], scores[2]);
-
-        if (results.size() == 1) return reliable;
 
         for (const CLD2::ResultChunk& chunk : chunks) {
             int index = static_cast<CLD2::Language>(chunk.lang1) == top3[0] ? 0 :

--- a/src/lang.hh
+++ b/src/lang.hh
@@ -2,28 +2,14 @@
 #define WARC2TEXT_LANG_HH
 
 #include <string>
-#include <vector>
+#include <unordered_map>
 #include <utility>
 #include "cld2/public/compact_lang_det.h"
 #include "cld2/public/encodings.h"
 
 namespace warc2text {
-    struct LanguageDetection {
-        std::string languageCode;
-        int percent;
-        double score;
-        std::vector<std::pair<std::size_t, std::size_t>> chunks; // each element is <offset, length>
-
-        LanguageDetection(const std::string& lang, int percent, double score) :
-            languageCode(lang),
-            percent(percent),
-            score(score)
-        {}
-
-    };
-
     // detect language of plain text, return top 3 languages
-    bool detectLanguage(const std::string& text, std::vector<LanguageDetection>& results);
+    bool detectLanguage(const std::string& text, std::unordered_map<std::string, std::string>& chunks);
 
     // detect top language of plain text
     bool detectLanguage(const std::string& text, std::string& lang);

--- a/src/lang.hh
+++ b/src/lang.hh
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <utility>
 #include "cld2/public/compact_lang_det.h"
 #include "cld2/public/encodings.h"
 
@@ -11,6 +12,7 @@ namespace warc2text {
         std::string languageCode;
         int percent;
         double score;
+        std::vector<std::pair<std::size_t, std::size_t>> chunks; // each element is <offset, length>
 
         LanguageDetection(const std::string& lang, int percent, double score) :
             languageCode(lang),

--- a/src/record.cc
+++ b/src/record.cc
@@ -233,9 +233,11 @@ namespace warc2text {
         return n_langs > 1;
     }
 
-    bool Record::detectLanguage(){
+    bool Record::detectLanguage(bool multilang){
+        if (not multilang) return warc2text::detectLanguage(plaintext, top_lang);
+
         bool reliable = warc2text::detectLanguage(plaintext, top3_langs);
-        if (reliable) top_language = top3_langs[0].languageCode;
+        if (reliable) top_lang = top3_langs[0].languageCode;
         return reliable;
     }
 
@@ -271,7 +273,7 @@ namespace warc2text {
     }
 
     const std::string& Record::getLanguage() const {
-        return top_language;
+        return top_lang;
     }
 
     const std::string& Record::getURL() const {

--- a/src/record.cc
+++ b/src/record.cc
@@ -209,7 +209,11 @@ namespace warc2text {
     }
 
     bool Record::detectLanguage(){
-        return warc2text::detectLanguage(plaintext, language);
+        // return warc2text::detectLanguage(plaintext, language);
+        std::vector<LanguageDetection> result;
+        bool reliable = warc2text::detectLanguage(plaintext, result);
+        if (reliable) language = result[0].languageCode;
+        return reliable;
     }
 
     const std::string& Record::getHeaderProperty(const std::string& property) const {

--- a/src/record.cc
+++ b/src/record.cc
@@ -214,7 +214,7 @@ namespace warc2text {
     int Record::detectLanguage(bool multilang){
         if (not multilang) return warc2text::detectLanguage(plaintext, language);
 
-        bool reliable = warc2text::detectLanguage(plaintext, text_by_langs);
+        warc2text::detectLanguage(plaintext, text_by_langs);
         return text_by_langs.size();
     }
 

--- a/src/record.cc
+++ b/src/record.cc
@@ -210,6 +210,7 @@ namespace warc2text {
     void Record::getTextByLanguageIndex(unsigned int index, std::string& out) const {
         out.clear();
         if (top3_langs.size() <= index) return;
+        out.reserve(plaintext.size() * (top3_langs[index].percent+1));
         for (const std::pair<std::size_t, std::size_t>& p : top3_langs[index].chunks) {
             out.append(plaintext, p.first, p.second);
         }

--- a/src/record.cc
+++ b/src/record.cc
@@ -207,38 +207,15 @@ namespace warc2text {
         return retval;
     }
 
-    void Record::getTextByLanguageIndex(unsigned int index, std::string& out) const {
-        out.clear();
-        if (top3_langs.size() <= index) return;
-        out.reserve(plaintext.size() * (top3_langs[index].percent+1));
-        for (const std::pair<std::size_t, std::size_t>& p : top3_langs[index].chunks) {
-            out.append(plaintext, p.first, p.second);
-        }
+    const std::unordered_map<std::string, std::string>& Record::getTextByLangs() const {
+        return text_by_langs;
     }
 
-    void Record::getLanguageByIndex(unsigned int index, std::string& out) const {
-        out.clear();
-        if (top3_langs.size() <= index) return;
-        out = top3_langs[index].languageCode;
-    }
+    int Record::detectLanguage(bool multilang){
+        if (not multilang) return warc2text::detectLanguage(plaintext, language);
 
-    bool Record::containsMultipleLanguages() const {
-        int n_langs = 0;
-        switch(top3_langs.size()) {
-            case 0: return false;
-            case 3: if (top3_langs[2].percent > 0) n_langs++;
-            case 2: if (top3_langs[1].percent > 0) n_langs++;
-            case 1: if (top3_langs[0].percent > 0) n_langs++;
-        }
-        return n_langs > 1;
-    }
-
-    bool Record::detectLanguage(bool multilang){
-        if (not multilang) return warc2text::detectLanguage(plaintext, top_lang);
-
-        bool reliable = warc2text::detectLanguage(plaintext, top3_langs);
-        if (reliable) top_lang = top3_langs[0].languageCode;
-        return reliable;
+        bool reliable = warc2text::detectLanguage(plaintext, text_by_langs);
+        return text_by_langs.size();
     }
 
     const std::string& Record::getHeaderProperty(const std::string& property) const {
@@ -273,7 +250,7 @@ namespace warc2text {
     }
 
     const std::string& Record::getLanguage() const {
-        return top_lang;
+        return language;
     }
 
     const std::string& Record::getURL() const {

--- a/src/record.hh
+++ b/src/record.hh
@@ -32,14 +32,12 @@ namespace warc2text {
         const std::string& getHTTPcontentType() const;
         const std::string& getCharset() const;
         bool isBroaderDocumentFormat() const;
-        bool containsMultipleLanguages() const;
 
-        void getTextByLanguageIndex(unsigned int index, std::string& out) const;
-        void getLanguageByIndex(unsigned int index, std::string& out) const;
+        const std::unordered_map<std::string, std::string>& getTextByLangs() const;
 
         int cleanPayload();
         int cleanPayload(const util::umap_tag_filters_regex& tagFilters);
-        bool detectLanguage(bool multilang);
+        int detectLanguage(bool multilang);
 
         static std::string readZipPayload(const std::string& content_type, const std::string& payload);
         static std::pair<std::string, bool> isPayloadZip(const std::string& content_type, const std::string& uri);
@@ -49,8 +47,9 @@ namespace warc2text {
         std::unordered_map<std::string, std::string> HTTPheader;
         std::string payload;
         std::string plaintext;
-        std::string top_lang;
-        std::vector<LanguageDetection> top3_langs;
+        std::string language;
+
+        std::unordered_map<std::string, std::string> text_by_langs;
 
         // these are present in the headers, but it's convenient to have them apart also
         std::string recordType;

--- a/src/record.hh
+++ b/src/record.hh
@@ -39,7 +39,7 @@ namespace warc2text {
 
         int cleanPayload();
         int cleanPayload(const util::umap_tag_filters_regex& tagFilters);
-        bool detectLanguage();
+        bool detectLanguage(bool multilang);
 
         static std::string readZipPayload(const std::string& content_type, const std::string& payload);
         static std::pair<std::string, bool> isPayloadZip(const std::string& content_type, const std::string& uri);
@@ -49,7 +49,7 @@ namespace warc2text {
         std::unordered_map<std::string, std::string> HTTPheader;
         std::string payload;
         std::string plaintext;
-        std::string top_language;
+        std::string top_lang;
         std::vector<LanguageDetection> top3_langs;
 
         // these are present in the headers, but it's convenient to have them apart also

--- a/src/record.hh
+++ b/src/record.hh
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <regex>
 #include "util.hh"
+#include "lang.hh"
 
 namespace warc2text {
     class Record {
@@ -31,6 +32,10 @@ namespace warc2text {
         const std::string& getHTTPcontentType() const;
         const std::string& getCharset() const;
         bool isBroaderDocumentFormat() const;
+        bool containsMultipleLanguages() const;
+
+        void getTextByLanguageIndex(unsigned int index, std::string& out) const;
+        void getLanguageByIndex(unsigned int index, std::string& out) const;
 
         int cleanPayload();
         int cleanPayload(const util::umap_tag_filters_regex& tagFilters);
@@ -39,12 +44,13 @@ namespace warc2text {
         static std::string readZipPayload(const std::string& content_type, const std::string& payload);
         static std::pair<std::string, bool> isPayloadZip(const std::string& content_type, const std::string& uri);
 
-            private:
+    private:
         std::unordered_map<std::string, std::string> header;
         std::unordered_map<std::string, std::string> HTTPheader;
         std::string payload;
         std::string plaintext;
-        std::string language;
+        std::string top_language;
+        std::vector<LanguageDetection> top3_langs;
 
         // these are present in the headers, but it's convenient to have them apart also
         std::string recordType;

--- a/src/util.cc
+++ b/src/util.cc
@@ -97,7 +97,7 @@ namespace util {
             if (boost::algorithm::all(line, boost::algorithm::is_space()) || boost::algorithm::starts_with(line, "#"))
                 continue;
             fields.clear();
-            boost::algorithm::split(fields, line, [](char c){return c == '\t';});    
+            boost::algorithm::split(fields, line, [](char c){return c == '\t';});
             if (fields.size() < 3) {
                 BOOST_LOG_TRIVIAL(warning) << "Could not parse tag filter at line " << line_i << " of " << filename;
                 continue;

--- a/src/warcpreprocessor.cc
+++ b/src/warcpreprocessor.cc
@@ -113,8 +113,7 @@ namespace warc2text {
             } else if (clean_retval == util::UTF8_CONVERSION_ERROR) {
                 BOOST_LOG_TRIVIAL(trace) << "Record " << record.getURL() << ": utf8 conversion error";
                 continue;
-            }
-            else if (clean_retval == util::NOT_VALID_RECORD) {
+            } else if (clean_retval == util::NOT_VALID_RECORD) {
                 BOOST_LOG_TRIVIAL(trace) << "Record " << record.getURL() << ": WARC or HTTP header content type not valid";
                 continue;
             }

--- a/src/warcpreprocessor.hh
+++ b/src/warcpreprocessor.hh
@@ -32,13 +32,14 @@ namespace warc2text {
             unsigned int langBytes;
             util::umap_tag_filters_regex tagFilters;
             std::string pdf_warc_filename;
+            bool invert;
+            bool multilang;
 
             static const std::unordered_set<std::string> removeExtensions;
             static bool URLfilter(const std::string& url);
-            bool invert;
 
         public:
-            explicit WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files = {}, const std::string& pdf_warc_filename = "", const std::string& tagFiltersFile = "", bool invert = false);
+            explicit WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files = {}, const std::string& pdf_warc_filename = "", const std::string& tagFiltersFile = "", bool invert = false, bool multilang = false);
             void process(const std::string &filename);
             void printStatistics() const;
     };

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -20,6 +20,7 @@ struct Options {
     std::string output;
     std::string tag_filters_filename;
     bool tag_filters_invert{};
+    bool multilang{};
 };
 
 void parseArgs(int argc, char *argv[], Options& out) {
@@ -34,7 +35,8 @@ void parseArgs(int argc, char *argv[], Options& out) {
         ("invert-tag-filters", po::bool_switch(&out.tag_filters_invert)->default_value(false), "Invert tag filter application")
         ("pdfpass", po::value(&out.pdf_warc_filename), "Write PDF records to WARC")
         ("verbose,v", po::bool_switch(&out.verbose)->default_value(false), "Verbosity level")
-        ("silent,s", po::bool_switch(&out.silent)->default_value(false));
+        ("silent,s", po::bool_switch(&out.silent)->default_value(false))
+        ("multilang", po::bool_switch(&out.multilang)->default_value(false), "Detect multiple languages in a single record");
 
     po::positional_options_description pd;
     pd.add("input", -1);
@@ -49,8 +51,10 @@ void parseArgs(int argc, char *argv[], Options& out) {
                 " -f <output_files>                List of output files separated by commas\n"
                 "                                  Default (mandatory): \"url,text\"\n"
                 "                                  Optional values: \"mime,html\"\n"
+                " --multilang                      Detect multiple languages in documents (up to 3),\n"
+                "                                  write as many text records as languages detected\n"
                 " --tag-filters <filters_files>    File containing filters\n"
-                "                                  Format: \"html_tag <tab> tag_attr <tab> value\"\n"
+                "                                  Format: \"html_tag <tab> tag_attr <tab> regexp\"\n"
                 " --invert-tag-filters             Only output records that got filtered\n"
                 " --pdfpass <output_warc>          Write PDF records to <output_warc>\n"
                 " -s                               Only output errors\n"
@@ -80,7 +84,7 @@ int main(int argc, char *argv[]) {
     std::unordered_set<std::string> output_files(files_list.begin(), files_list.end());
 
     std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-    WARCPreprocessor warcpproc(options.output, output_files, options.pdf_warc_filename, options.tag_filters_filename, options.tag_filters_invert);
+    WARCPreprocessor warcpproc(options.output, output_files, options.pdf_warc_filename, options.tag_filters_filename, options.tag_filters_invert, options.multilang);
     for (const std::string& file : options.warcs){
         warcpproc.process(file);
     }


### PR DESCRIPTION
CLD2 detects top 3 languages of the document and returns a vector of chunks corresponding to different languages. These chunks are joined to generate one record per language; and each record is written to the corresponding file on disk.
This functionality is enabled with `--multilang`