### PR TITLE
Add url filter, similar to the tag filter we use for MT

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,15 @@ warc2text -o <output_folder> [ -f <output_files> ] [ --pdfpass <output_warc> ] [
 * `--pdfpass` WARC file where PDF records will be stored
 * `--tag-filters` file containing filters that are used to eliminate matching documents
 * `--invert-tag-filters` output only documents that match the filter
+* `--url-filters` file containing regular expressions that match urls of documents to eliminate
 * `--verbose`/`-v` print progress and filtering information
 * `--silent`/`-s` print only warnings and errors
 
-  Filter format is the following: `tag <tab> attribute <tab> regexp`
+  Tag Filter format is the following: `tag <tab> attribute <tab> regexp`
   
   For example, `meta <tab> name <tab> translation-stats` will remove documents that contain `<meta name="translation-stats" ... >`
+
+  URL Filter format is a single regular expression per line.
 
   Lines beginning with `#` and empty lines are ignored. Any invalid filter will raise a warning message, but will not prevent other filters from being read.
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -113,6 +113,25 @@ namespace util {
         f.close();
     }
 
+    void readUrlFiltersRegex(const std::string &filename, std::vector<umap_attr_regex>& filters) {
+        std::ifstream f(filename);
+        std::string line;
+        for (size_t line_i=1; std::getline(f, line); ++line_i) {
+            if (boost::algorithm::all(line, boost::algorithm::is_space()) || boost::algorithm::starts_with(line, "#"))
+                continue;
+            try {
+                filters.emplace_back((umap_attr_regex) {
+                    std::regex(line, std::regex::optimize),
+                    line
+                });
+            } catch (const std::regex_error& e) {
+                BOOST_LOG_TRIVIAL(warning) << "Coul not parse url filter at " << filename << ":" << line_i << ": " << e.what();
+                continue;
+            }
+        }
+        f.close();
+    }
+
     bool createDirectories(const std::string& path){
         if (!boost::filesystem::exists(path))
             return boost::filesystem::create_directories(path);

--- a/src/util.hh
+++ b/src/util.hh
@@ -51,6 +51,8 @@ namespace util {
 
     void readTagFiltersRegex(const std::string& filename, umap_tag_filters_regex& filters);
 
+    void readUrlFiltersRegex(const std::string &filename, std::vector<umap_attr_regex>& filters);
+
     bool createDirectories(const std::string& path);
 }
 

--- a/src/warcpreprocessor.hh
+++ b/src/warcpreprocessor.hh
@@ -31,15 +31,16 @@ namespace warc2text {
             unsigned int textBytes;
             unsigned int langBytes;
             util::umap_tag_filters_regex tagFilters;
+            std::vector<util::umap_attr_regex> urlFilters;
             std::string pdf_warc_filename;
             bool invert;
             bool multilang;
 
             static const std::unordered_set<std::string> removeExtensions;
-            static bool URLfilter(const std::string& url);
+            bool URLfilter(const std::string& url);
 
         public:
-            explicit WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files = {}, const std::string& pdf_warc_filename = "", const std::string& tagFiltersFile = "", bool invert = false, bool multilang = false);
+            explicit WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files = {}, const std::string& pdf_warc_filename = "", const std::string& tagFiltersFile = "", bool invert = false, const std::string& urlFiltersFile = "", bool multilang = false);
             void process(const std::string &filename);
             void printStatistics() const;
     };

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -20,6 +20,7 @@ struct Options {
     std::string output;
     std::string tag_filters_filename;
     bool tag_filters_invert{};
+    std::string url_filters_filename;
     bool multilang{};
 };
 
@@ -33,6 +34,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
         ("input,i", po::value(&out.warcs)->multitoken(), "Input WARC file name(s)")
         ("tag-filters", po::value(&out.tag_filters_filename), "Plain text file containing tag filters")
         ("invert-tag-filters", po::bool_switch(&out.tag_filters_invert)->default_value(false), "Invert tag filter application")
+        ("url-filters", po::value(&out.url_filters_filename), "Plain text file containing url filters")
         ("pdfpass", po::value(&out.pdf_warc_filename), "Write PDF records to WARC")
         ("verbose,v", po::bool_switch(&out.verbose)->default_value(false), "Verbosity level")
         ("silent,s", po::bool_switch(&out.silent)->default_value(false))
@@ -53,9 +55,11 @@ void parseArgs(int argc, char *argv[], Options& out) {
                 "                                  Optional values: \"mime,html\"\n"
                 " --multilang                      Detect multiple languages in documents (up to 3),\n"
                 "                                  write as many text records as languages detected\n"
-                " --tag-filters <filters_files>    File containing filters\n"
+                " --tag-filters <filters_files>    File containing html tag filters\n"
                 "                                  Format: \"html_tag <tab> tag_attr <tab> regexp\"\n"
                 " --invert-tag-filters             Only output records that got filtered\n"
+                " --url-filters <filters_file>     File containing url filters\n"
+                "                                  Format: \"regexp\"\n"
                 " --pdfpass <output_warc>          Write PDF records to <output_warc>\n"
                 " -s                               Only output errors\n"
                 " -v                               Verbose output (print trace)\n\n";
@@ -84,7 +88,7 @@ int main(int argc, char *argv[]) {
     std::unordered_set<std::string> output_files(files_list.begin(), files_list.end());
 
     std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-    WARCPreprocessor warcpproc(options.output, output_files, options.pdf_warc_filename, options.tag_filters_filename, options.tag_filters_invert, options.multilang);
+    WARCPreprocessor warcpproc(options.output, output_files, options.pdf_warc_filename, options.tag_filters_filename, options.tag_filters_invert, options.url_filters_filename, options.multilang);
     for (const std::string& file : options.warcs){
         warcpproc.process(file);
     }


### PR DESCRIPTION
I tried to keep it consistent with the tag filter already implemented.

Basically it allows you to write regular expressions that match parts of the url. If the url matches, the document is filtered. Fairly simple.

URL filter format is a single regular expression per line. Empty lines and line starting with `#` are allowed, just like in the tag filter file. Parse errors result in a warning and the line being skipped.