### PR TITLE
Add --encode-urls option to deal with unescaped chars in URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 build/
 debug/
 *.swp

--- a/src/entities.cc
+++ b/src/entities.cc
@@ -12,7 +12,7 @@
 namespace entities {
 
     // pos is the index of '&'
-    // return value is the index of ';', or the intex of the first invalid character
+    // return value is the index of ';', or the index of the first invalid character
     // return value will be std::string::npos if the entity ends without ';' at the end
     std::size_t findEntityEnd(const std::string& source, std::size_t pos) {
         bool numeric = false;

--- a/src/record.cc
+++ b/src/record.cc
@@ -288,4 +288,8 @@ namespace warc2text {
         return textContentTypes.find(cleanHTTPcontentType) != textContentTypes.end();
     }
 
+    void Record::encodeURL() {
+        url = util::encodeURLs(url);
+    }
+
 } // warc2text

--- a/src/record.hh
+++ b/src/record.hh
@@ -43,6 +43,8 @@ namespace warc2text {
         static std::string readZipPayload(const std::string& content_type, const std::string& payload);
         static std::string isPayloadZip(const std::string& content_type, const std::string& uri);
 
+        void encodeURL();
+
     private:
         std::unordered_map<std::string, std::string> header;
         std::unordered_map<std::string, std::string> HTTPheader;

--- a/src/util.cc
+++ b/src/util.cc
@@ -138,4 +138,28 @@ namespace util {
         else return false; // throw exception??
     }
 
+    std::string encodeURLs(const std::string& in) {
+        std::ostringstream out;
+        out << std::hex;
+
+        for (char c : in){
+            // allowed characters
+            if (std::isalnum(c) or c == '-' or c == '.' or c == '~') {
+                out << c;
+            }
+
+            // characters with a reserved purpose
+            // should be percent-encoded when used as data within a URI, but how do we tell?
+            else if (reserved_chars_url.find(c) != std::string::npos){
+                out << c;
+            }
+
+            // characters that should always be escaped
+            else {
+                out << "%" << int(c);
+            }
+        }
+        return out.str();
+    }
+
 }

--- a/src/util.hh
+++ b/src/util.hh
@@ -28,6 +28,9 @@ namespace util {
 
     void decodeBase64(const std::string& base64, std::string& output);
 
+    const std::string reserved_chars_url("!#$&'()*+,/:;=?[]");
+    std::string encodeURLs(const std::string& url);
+
     enum ErrorCode : int {
         SUCCESS = 0,
         HTML_PARSING_ERROR = 1,

--- a/src/warcpreprocessor.cc
+++ b/src/warcpreprocessor.cc
@@ -7,7 +7,7 @@
 namespace warc2text {
     const std::unordered_set<std::string> WARCPreprocessor::removeExtensions = {".jpg", ".jpeg", ".gif", ".png", ".css", ".js", ".mp3", ".mp4", ".flv", ".wmv", ".gz", ".zip", ".rar" };
 
-    WARCPreprocessor::WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files, const std::string& pdf_warc_filename, const std::string& tagFiltersFile, bool invert, const std::string& urlFiltersFile, bool multilang) :
+    WARCPreprocessor::WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files, const std::string& pdf_warc_filename, const std::string& tagFiltersFile, bool invert, const std::string& urlFiltersFile, bool multilang, bool encodeURLs) :
         writer(outputFolder, output_files),
         totalRecords(0),
         textRecords(0),
@@ -19,7 +19,8 @@ namespace warc2text {
         urlFilters(),
         pdf_warc_filename(pdf_warc_filename),
         invert(invert),
-        multilang(multilang) {
+        multilang(multilang),
+        encodeURLs(encodeURLs) {
             if (!tagFiltersFile.empty())
                 util::readTagFiltersRegex(tagFiltersFile, tagFilters);
 
@@ -99,6 +100,9 @@ namespace warc2text {
 
             if (!URLfilter(record.getURL()))
                 continue;
+
+            if (encodeURLs)
+                record.encodeURL();
 
             BOOST_LOG_TRIVIAL(trace) << "Processing HTML document " << record.getURL() << "\n";
 

--- a/src/warcpreprocessor.cc
+++ b/src/warcpreprocessor.cc
@@ -85,10 +85,10 @@ namespace warc2text {
                         BOOST_LOG_TRIVIAL(info) << "PDF too large to compress with util::GZCompress";
                         continue;
                     }
-                    
+
                     if (!pdf_warc_writer.is_open())
                         pdf_warc_writer.open(pdf_warc_filename);
-                
+
                     pdf_warc_writer.writeRecord(content);
                 }
                 continue;
@@ -111,7 +111,7 @@ namespace warc2text {
             }
             catch (std::out_of_range& e) { continue; }
             catch (std::invalid_argument& e) { continue; }
-            catch (util::ZipReadError& e) { 
+            catch (util::ZipReadError& e) {
                 BOOST_LOG_TRIVIAL(info) << "Record " << record.getURL() << " discarded due to invalid zip file: " << e.what();
                 continue;
             }

--- a/src/warcpreprocessor.hh
+++ b/src/warcpreprocessor.hh
@@ -35,12 +35,13 @@ namespace warc2text {
             std::string pdf_warc_filename;
             bool invert;
             bool multilang;
+            bool encodeURLs;
 
             static const std::unordered_set<std::string> removeExtensions;
             bool URLfilter(const std::string& url);
 
         public:
-            explicit WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files = {}, const std::string& pdf_warc_filename = "", const std::string& tagFiltersFile = "", bool invert = false, const std::string& urlFiltersFile = "", bool multilang = false);
+            explicit WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files = {}, const std::string& pdf_warc_filename = "", const std::string& tagFiltersFile = "", bool invert = false, const std::string& urlFiltersFile = "", bool multilang = false, bool encodeURLs = false);
             void process(const std::string &filename);
             void printStatistics() const;
     };

--- a/src/zipreader.cc
+++ b/src/zipreader.cc
@@ -52,7 +52,7 @@ std::string ZipEntry::read(std::string &&buffer) const {
     zip_stat_t st;
     zip_stat_init(&st);
     zip_stat_index(archive_.get(), index_, 0, &st);
-    
+
     // Open pointer to file inside zip
     std::unique_ptr<zip_file_t, decltype(&zip_fclose)> fh(zip_fopen_index(archive_.get(), index_, 0), &zip_fclose);
     if (!fh)
@@ -60,7 +60,7 @@ std::string ZipEntry::read(std::string &&buffer) const {
 
     // Make room for uncompressed data
     buffer.resize(st.size);
-    
+
     // Read uncompressed data (in a loop in case it can't be done in one read?)
     for (size_t read = 0; read < buffer.size();) {
         auto len = zip_fread(fh.get(), &buffer[0] + read, buffer.size() - read);

--- a/src/zipreader.hh
+++ b/src/zipreader.hh
@@ -31,7 +31,7 @@ public:
     friend bool operator==(const ZipEntry& a, const ZipEntry& b) {
         return a.archive_ == b.archive_ && a.index_ == b.index_;
     };
-    
+
     friend bool operator!=(const ZipEntry& a, const ZipEntry& b) {
         return a.archive_ != b.archive_ || a.index_ != b.index_;
     };
@@ -78,7 +78,7 @@ public:
     friend bool operator==(const ZipEntryIterator& a, const ZipEntryIterator& b) {
         return a.entry_ == b.entry_;
     };
-    
+
     friend bool operator!=(const ZipEntryIterator& a, const ZipEntryIterator& b) {
         return a.entry_ != b.entry_;
     };
@@ -86,14 +86,14 @@ public:
 
 /**
  * Class to iterate over files in an in-memory zip archive.
- * 
+ *
  * Example:
- * 
+ *
  *   ZipReader reader(buffer);
  *   for (auto file : reader)
  *     if (file.name() == "something.txt")
  *       std::cerr << file.read();
- * 
+ *
  */
 class ZipReader {
 private:
@@ -110,7 +110,7 @@ public:
     const_iterator begin() const {
         return ZipEntryIterator(archive_, 0);
     }
-    
+
     const_iterator end() const {
         return ZipEntryIterator(archive_, size());
     }

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -22,6 +22,7 @@ struct Options {
     bool tag_filters_invert{};
     std::string url_filters_filename;
     bool multilang{};
+    bool encodeURLs{};
 };
 
 void parseArgs(int argc, char *argv[], Options& out) {
@@ -38,7 +39,8 @@ void parseArgs(int argc, char *argv[], Options& out) {
         ("pdfpass", po::value(&out.pdf_warc_filename), "Write PDF records to WARC")
         ("verbose,v", po::bool_switch(&out.verbose)->default_value(false), "Verbosity level")
         ("silent,s", po::bool_switch(&out.silent)->default_value(false))
-        ("multilang", po::bool_switch(&out.multilang)->default_value(false), "Detect multiple languages in a single record");
+        ("multilang", po::bool_switch(&out.multilang)->default_value(false), "Detect multiple languages in a single record")
+        ("encode-urls", po::bool_switch(&out.encodeURLs)->default_value(false), "Encode URLs obtained from WARC records");
 
     po::positional_options_description pd;
     pd.add("input", -1);
@@ -61,6 +63,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
                 " --url-filters <filters_file>     File containing url filters\n"
                 "                                  Format: \"regexp\"\n"
                 " --pdfpass <output_warc>          Write PDF records to <output_warc>\n"
+                " --encode-urls                    Encode URLs obtained from WARC records\n"
                 " -s                               Only output errors\n"
                 " -v                               Verbose output (print trace)\n\n";
         exit(1);
@@ -88,7 +91,7 @@ int main(int argc, char *argv[]) {
     std::unordered_set<std::string> output_files(files_list.begin(), files_list.end());
 
     std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-    WARCPreprocessor warcpproc(options.output, output_files, options.pdf_warc_filename, options.tag_filters_filename, options.tag_filters_invert, options.url_filters_filename, options.multilang);
+    WARCPreprocessor warcpproc(options.output, output_files, options.pdf_warc_filename, options.tag_filters_filename, options.tag_filters_invert, options.url_filters_filename, options.multilang, options.encodeURLs);
     for (const std::string& file : options.warcs){
         warcpproc.process(file);
     }


### PR DESCRIPTION
Special characters that have no business being in URLs will be escaped (i.e. spaces will become `%20`)
Reserved characters that normally have a purpose, such as `/`, `?`, `&`, `=`, `#`, etc. will be left as is, because it is not trivial to detect when they are being used for their purpose or if they are a part of the data. Unless escaping those is also important @jelmervdl ?

The flag to activate this is `--encode-urls`