### PR TITLE
Mark url filter notices as level "info"

### DIFF
--- a/src/warcpreprocessor.cc
+++ b/src/warcpreprocessor.cc
@@ -39,7 +39,7 @@ namespace warc2text {
         for (auto &&filter : urlFilters) {
             std::smatch match;
             if (std::regex_search(url, match, filter.regex)) {
-                BOOST_LOG_TRIVIAL(debug) << "Url filter " << filter.str << " matched '" << match.str() << "' in value '" << url << "'";
+                BOOST_LOG_TRIVIAL(info) << "Url filter " << filter.str << " matched '" << match.str() << "' in value '" << url << "'";
                 return false;
             }
         }


### PR DESCRIPTION
I messed up earlier and marked them as debug. This change marks them as info, the same level as omissions due to the tag filter.