### PR TITLE
Optimize regex filters

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,7 @@ find_path(uchardet_INCLUDE_DIR uchardet/uchardet.h
 )
 
 find_package(ZLIB 1.2.11 REQUIRED)
-find_package( Boost 1.71 COMPONENTS locale iostreams filesystem log REQUIRED )
+find_package( Boost 1.71 COMPONENTS locale iostreams filesystem log regex REQUIRED )
 
 include_directories(
     ${ZLIB_INCLUDE_DIR}

--- a/src/html.cc
+++ b/src/html.cc
@@ -17,9 +17,8 @@ namespace warc2text {
         if (attr_it == tag_it->second.cend())
             return true;
         for (const util::umap_attr_regex& filter : attr_it->second){
-            std::cmatch match;
-            if (std::regex_search(value, match, filter.regex)) {
-                BOOST_LOG_TRIVIAL(debug) << "Tag filter " << tag_it->first << "[" << attr_it->first << " ~ " << filter.str << "] matched '" << match.str() << "' in value '" << value << "'";
+            if (std::regex_search(value, filter.regex)) {
+                BOOST_LOG_TRIVIAL(debug) << "Tag filter " << tag_it->first << "[" << attr_it->first << " ~ " << filter.str << "] matched '" << value << "'";
                 return false;
             }
         }

--- a/src/util.cc
+++ b/src/util.cc
@@ -1,5 +1,6 @@
 #include "util.hh"
 #include <fstream>
+#include <sstream>
 #include <algorithm>
 #include <vector>
 #include <boost/filesystem.hpp>
@@ -113,23 +114,29 @@ namespace util {
         f.close();
     }
 
-    void readUrlFiltersRegex(const std::string &filename, std::vector<umap_attr_regex>& filters) {
+    void readUrlFiltersRegex(const std::string &filename, std::regex &urlFilter) {
         std::ifstream f(filename);
         std::string line;
+        std::ostringstream combined;
+        bool first = true;
         for (size_t line_i=1; std::getline(f, line); ++line_i) {
             if (boost::algorithm::all(line, boost::algorithm::is_space()) || boost::algorithm::starts_with(line, "#"))
                 continue;
             try {
-                filters.emplace_back((umap_attr_regex) {
-                    std::regex(line, std::regex::optimize),
-                    line
-                });
+                (std::regex(line)); // Compile, but just to test its validity.
+                if (first)
+                    first = false;
+                else
+                    combined << "|";
+                combined << "(" << line << ")";
             } catch (const std::regex_error& e) {
-                BOOST_LOG_TRIVIAL(warning) << "Coul not parse url filter at " << filename << ":" << line_i << ": " << e.what();
+                BOOST_LOG_TRIVIAL(warning) << "Could not parse url filter at " << filename << ":" << line_i << ": " << e.what();
                 continue;
             }
         }
         f.close();
+
+        urlFilter.assign(combined.str(), std::regex::optimize | std::regex::nosubs);
     }
 
     bool createDirectories(const std::string& path){

--- a/src/util.cc
+++ b/src/util.cc
@@ -106,7 +106,7 @@ namespace util {
             std::vector<umap_attr_regex>& values = attrs[fields.at(1)];
             for (unsigned int i = 2; i < fields.size(); ++i)
                 values.emplace_back((umap_attr_regex){
-                    std::regex(fields.at(i), std::regex::optimize),
+                    std::regex(fields.at(i), std::regex::optimize | std::regex::nosubs),
                     fields.at(i)
                 });
         }

--- a/src/util.cc
+++ b/src/util.cc
@@ -114,7 +114,7 @@ namespace util {
         f.close();
     }
 
-    void readUrlFiltersRegex(const std::string &filename, std::regex &urlFilter) {
+    void readUrlFiltersRegex(const std::string &filename, boost::regex &urlFilter) {
         std::ifstream f(filename);
         std::string line;
         std::ostringstream combined;
@@ -123,20 +123,20 @@ namespace util {
             if (boost::algorithm::all(line, boost::algorithm::is_space()) || boost::algorithm::starts_with(line, "#"))
                 continue;
             try {
-                (std::regex(line)); // Compile, but just to test its validity.
+                (boost::regex(line)); // Compile, but just to test its validity.
                 if (first)
                     first = false;
                 else
                     combined << "|";
                 combined << "(" << line << ")";
-            } catch (const std::regex_error& e) {
+            } catch (const boost::regex_error& e) {
                 BOOST_LOG_TRIVIAL(warning) << "Could not parse url filter at " << filename << ":" << line_i << ": " << e.what();
                 continue;
             }
         }
         f.close();
 
-        urlFilter.assign(combined.str(), std::regex::optimize | std::regex::nosubs);
+        urlFilter.assign(combined.str(), boost::regex::optimize | boost::regex::nosubs);
     }
 
     bool createDirectories(const std::string& path){

--- a/src/util.hh
+++ b/src/util.hh
@@ -54,7 +54,7 @@ namespace util {
 
     void readTagFiltersRegex(const std::string& filename, umap_tag_filters_regex& filters);
 
-    void readUrlFiltersRegex(const std::string &filename, std::vector<umap_attr_regex>& filters);
+    void readUrlFiltersRegex(const std::string &filename, std::regex &urlFilter);
 
     bool createDirectories(const std::string& path);
 }

--- a/src/util.hh
+++ b/src/util.hh
@@ -6,6 +6,7 @@
 #include <unordered_set>
 #include <vector>
 #include <regex>
+#include <boost/regex.hpp>
 
 namespace util {
     void toLower(std::string& s);
@@ -54,7 +55,7 @@ namespace util {
 
     void readTagFiltersRegex(const std::string& filename, umap_tag_filters_regex& filters);
 
-    void readUrlFiltersRegex(const std::string &filename, std::regex &urlFilter);
+    void readUrlFiltersRegex(const std::string &filename, boost::regex &urlFilter);
 
     bool createDirectories(const std::string& path);
 }

--- a/src/warcpreprocessor.cc
+++ b/src/warcpreprocessor.cc
@@ -36,7 +36,7 @@ namespace warc2text {
             if (boost::algorithm::ends_with(url, ext))
                 return false;
 
-        if (std::regex_search(url, urlFilter)) {
+        if (boost::regex_search(url, urlFilter)) {
             BOOST_LOG_TRIVIAL(info) << "Url filter matched '" << url << "'";
             return false;
         }

--- a/src/warcpreprocessor.cc
+++ b/src/warcpreprocessor.cc
@@ -16,7 +16,6 @@ namespace warc2text {
         textBytes(0),
         langBytes(0),
         tagFilters(),
-        urlFilters(),
         pdf_warc_filename(pdf_warc_filename),
         invert(invert),
         multilang(multilang),
@@ -25,7 +24,7 @@ namespace warc2text {
                 util::readTagFiltersRegex(tagFiltersFile, tagFilters);
 
             if (!urlFiltersFile.empty())
-                util::readUrlFiltersRegex(urlFiltersFile, urlFilters);
+                util::readUrlFiltersRegex(urlFiltersFile, urlFilter);
         }
 
     // true if url is good
@@ -37,12 +36,9 @@ namespace warc2text {
             if (boost::algorithm::ends_with(url, ext))
                 return false;
 
-        for (auto &&filter : urlFilters) {
-            std::smatch match;
-            if (std::regex_search(url, match, filter.regex)) {
-                BOOST_LOG_TRIVIAL(info) << "Url filter " << filter.str << " matched '" << match.str() << "' in value '" << url << "'";
-                return false;
-            }
+        if (std::regex_search(url, urlFilter)) {
+            BOOST_LOG_TRIVIAL(info) << "Url filter matched '" << url << "'";
+            return false;
         }
         
         return true;

--- a/src/warcpreprocessor.cc
+++ b/src/warcpreprocessor.cc
@@ -36,7 +36,7 @@ namespace warc2text {
             if (boost::algorithm::ends_with(url, ext))
                 return false;
 
-        if (boost::regex_search(url, urlFilter)) {
+        if (!urlFilter.empty() && boost::regex_search(url, urlFilter)) {
             BOOST_LOG_TRIVIAL(info) << "Url filter matched '" << url << "'";
             return false;
         }

--- a/src/warcpreprocessor.hh
+++ b/src/warcpreprocessor.hh
@@ -7,6 +7,7 @@
 #include "util.hh"
 #include <string>
 #include <unordered_set>
+#include <boost/regex.hpp>
 
 namespace warc2text {
     class WARCWriter {
@@ -31,7 +32,7 @@ namespace warc2text {
             unsigned int textBytes;
             unsigned int langBytes;
             util::umap_tag_filters_regex tagFilters;
-            std::regex urlFilter;
+            boost::regex urlFilter;
             std::string pdf_warc_filename;
             bool invert;
             bool multilang;

--- a/src/warcpreprocessor.hh
+++ b/src/warcpreprocessor.hh
@@ -31,7 +31,7 @@ namespace warc2text {
             unsigned int textBytes;
             unsigned int langBytes;
             util::umap_tag_filters_regex tagFilters;
-            std::vector<util::umap_attr_regex> urlFilters;
+            std::regex urlFilter;
             std::string pdf_warc_filename;
             bool invert;
             bool multilang;


### PR DESCRIPTION
My url filter implementation is really slowing down warc2text right now, being the slowest part of the process after decompression (no 1) and uchardet (no 2) 😅

I've tried a number of optimisations, and this combination seems to be the fastest:
- Skip storing submatches: saves a lot of tiny allocations
- Combine all regular expressions into a large one for the URL filter
- Switch out std::regex for boost::regex (which seems to be quite a bit better at optimising)

Runtimes on a single wide6 warc:
| Setting | Time |
| --- | ---: |
| master with url filter* (35 entries) | 1:15 |
| master with url filter** (1 entry) | 0:52 |
| master without url filter | 0:47 |
| this branch with url filter (35 entries) | 0:50 |
| this branch with url filter** (1 entry) | 0:48 |

*) The url filter list I used matched only 3 of the 29223 documents, so the number of filtered out documents should have little effect on the numbers above.
**) The single entry url filter is the previous filter, but merged in the form of `^(https?:)?(//)?((pattern1)|(pattern2)|...)`

I'm a bit sad that the 35 entries vs 1 entry still has such a difference. I would have hoped that using the `optimize` flag they would have collapsed into similar state machines. But this does not seem to happen.