### PR TITLE
Don't parse text/plain as HTML

### DIFF
--- a/src/record.cc
+++ b/src/record.cc
@@ -205,17 +205,26 @@ namespace warc2text {
         // throw out documents if we don't know the charset
         else return util::UNKNOWN_ENCODING_ERROR;
 
+        bool needToConvert = !(charset == "utf8" or charset == "utf-8" or charset == "ascii");
+        bool isPlainText = cleanHTTPcontentType == "text/plain";
+        
+        int retval = util::SUCCESS;
+
         // remove HTML tags:
-        int retval = processHTML(payload, extracted, tagFilters);
+        if (isPlainText)
+            util::trimLinesCopy(payload, extracted);
+        else
+            retval = processHTML(payload, extracted, tagFilters);
 
         // convert to utf8 if needed:
-        bool needToConvert = !(charset == "utf8" or charset == "utf-8" or charset == "ascii");
-        if (needToConvert) {
+        if (needToConvert)
             extracted = util::toUTF8(extracted, charset);
-        }
 
         // decode HTML entities:
-        entities::decodeEntities(extracted, plaintext);
+        if (isPlainText)
+            plaintext = extracted;
+        else
+            entities::decodeEntities(extracted, plaintext);
 
         return retval;
     }


### PR DESCRIPTION
PDF processing generates these plain text documents. But I noticed that when I feed these warcs with just plain/text documents, parsing will fail and the document will be dropped.

This change does assume that there are generally no html documents (or anything else that goes through `processHTML`) served with text/plain; there's no heuristic for determining whether something is plain text or not.