### PR TITLE
Paragraph identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ git clone --recurse-submodules https://github.com/bitextor/warc2text.git
 Or:
 ```
 git clone https://github.com/bitextor/warc2text.git
-git submodule update --init
+git submodule update --init --recursive
 ```
 
 ## Install dependencies

--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ make install
 
 ## Usage
 ```
-warc2text -o <output_folder> [ -f <output_files> ] [ --pdfpass <output_warc> ] [ --tag-filters <filters_file> ] <warc_file>...
+warc2text -o <output_folder> [ -f <output_files> ] [ --pdfpass <output_warc> ]
+          [ --paragraph-identification ] [ --tag-filters <filters_file> ] <warc_file>...
 ```
 * `--output`/`-o` output folder
 * `--files`/`-f` list of output files separated by commas (and without `.gz`); `text` and `url` are always written, while `mime` and `html` are optional
 * `--pdfpass` WARC file where PDF records will be stored
+* `--paragraph-identification` print the paragraph identifier for each sentence extracted from the HTML
 * `--tag-filters` file containing filters that are used to eliminate matching documents
 * `--invert-tag-filters` output only documents that match the filter
 * `--url-filters` file containing regular expressions that match urls of documents to eliminate

--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -97,7 +97,7 @@ namespace warc2text{
         std::string result = "";
         std::vector<std::string> lines = util::split(text, "\n");
 
-        while (lines[lines.size() - 1] == "\n") {
+        while (lines[lines.size() - 1] == "") {
             lines.pop_back();
         }
 

--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -97,6 +97,10 @@ namespace warc2text{
         std::string result = "";
         std::vector<std::string> lines = util::split(text, "\n");
 
+        while (lines[lines.size() - 1] == "\n") {
+            lines.pop_back();
+        }
+
         for (size_t i = 0; i < lines.size(); ++i) {
             result += lines[i] + "\t" + std::to_string(i) + "\n";
         }

--- a/src/bilangwriter.hh
+++ b/src/bilangwriter.hh
@@ -57,7 +57,7 @@ namespace warc2text {
                 output_files(output_files)
             {};
 
-            void write(const Record& record, bool multilang = false);
+            void write(const Record& record, bool multilang = false, bool paragraph_identification = false);
 
     };
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -169,4 +169,21 @@ namespace util {
         return out.str();
     }
 
+    std::vector<std::string> split(const std::string& s, const std::string& delimiter)
+    {
+        std::vector<std::string> result;
+        size_t pos = 0, previous_pos = 0;
+        std::string token;
+
+        while ((pos = s.find(delimiter, previous_pos)) != std::string::npos) {
+            result.push_back(s.substr(previous_pos, pos - previous_pos));
+
+            previous_pos = pos + delimiter.size();
+        }
+
+        result.push_back(s.substr(previous_pos, s.size() - previous_pos));
+
+        return result;
+    }
+
 }

--- a/src/util.hh
+++ b/src/util.hh
@@ -58,6 +58,8 @@ namespace util {
     void readUrlFiltersRegex(const std::string &filename, boost::regex &urlFilter);
 
     bool createDirectories(const std::string& path);
+
+    std::vector<std::string> split(const std::string& s, const std::string& delimiter);
 }
 
 namespace html {

--- a/src/warcpreprocessor.cc
+++ b/src/warcpreprocessor.cc
@@ -5,9 +5,13 @@
 #include <boost/algorithm/string/predicate.hpp>
 
 namespace warc2text {
-    const std::unordered_set<std::string> WARCPreprocessor::removeExtensions = {".jpg", ".jpeg", ".gif", ".png", ".css", ".js", ".mp3", ".mp4", ".flv", ".wmv", ".gz", ".zip", ".rar" };
+    const std::unordered_set<std::string> WARCPreprocessor::removeExtensions = {".jpg", ".jpeg", ".gif", ".png", ".css", ".js", ".mp3",
+                                                                                ".mp4", ".flv", ".wmv", ".gz", ".zip", ".rar" };
 
-    WARCPreprocessor::WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files, const std::string& pdf_warc_filename, const std::string& tagFiltersFile, bool invert, const std::string& urlFiltersFile, bool multilang, bool encodeURLs) :
+    WARCPreprocessor::WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files,
+                                       const std::string& pdf_warc_filename, const std::string& tagFiltersFile, bool invert,
+                                       const std::string& urlFiltersFile, bool multilang, bool encodeURLs,
+                                       bool paragraph_identification) :
         writer(outputFolder, output_files),
         totalRecords(0),
         textRecords(0),
@@ -19,7 +23,8 @@ namespace warc2text {
         pdf_warc_filename(pdf_warc_filename),
         invert(invert),
         multilang(multilang),
-        encodeURLs(encodeURLs) {
+        encodeURLs(encodeURLs),
+        paragraph_identification(paragraph_identification) {
             if (!tagFiltersFile.empty())
                 util::readTagFiltersRegex(tagFiltersFile, tagFilters);
 
@@ -155,7 +160,7 @@ namespace warc2text {
 
             langRecords += n_langs;
 
-            writer.write(record, multilang);
+            writer.write(record, multilang, paragraph_identification);
         }
         pdf_warc_writer.close();
     }

--- a/src/warcpreprocessor.hh
+++ b/src/warcpreprocessor.hh
@@ -37,12 +37,16 @@ namespace warc2text {
             bool invert;
             bool multilang;
             bool encodeURLs;
+            bool paragraph_identification;
 
             static const std::unordered_set<std::string> removeExtensions;
             bool URLfilter(const std::string& url);
 
         public:
-            explicit WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files = {}, const std::string& pdf_warc_filename = "", const std::string& tagFiltersFile = "", bool invert = false, const std::string& urlFiltersFile = "", bool multilang = false, bool encodeURLs = false);
+            explicit WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files = {},
+                                      const std::string& pdf_warc_filename = "", const std::string& tagFiltersFile = "",
+                                      bool invert = false, const std::string& urlFiltersFile = "", bool multilang = false,
+                                      bool encodeURLs = false, bool paragraph_identification = false);
             void process(const std::string &filename);
             void printStatistics() const;
     };

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -15,6 +15,7 @@ struct Options {
     std::vector<std::string> warcs;
     std::string files;
     std::string pdf_warc_filename;
+    bool paragraph_identification{};
     bool verbose{};
     bool silent{};
     std::string output;
@@ -37,6 +38,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
         ("invert-tag-filters", po::bool_switch(&out.tag_filters_invert)->default_value(false), "Invert tag filter application")
         ("url-filters", po::value(&out.url_filters_filename), "Plain text file containing url filters")
         ("pdfpass", po::value(&out.pdf_warc_filename), "Write PDF records to WARC")
+        ("paragraph-identification", po::bool_switch(&out.paragraph_identification)->default_value(false), "Add paragraph index in each b64encoded document as tab separated column")
         ("verbose,v", po::bool_switch(&out.verbose)->default_value(false), "Verbosity level")
         ("silent,s", po::bool_switch(&out.silent)->default_value(false))
         ("multilang", po::bool_switch(&out.multilang)->default_value(false), "Detect multiple languages in a single record")
@@ -64,6 +66,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
                 "                                  Format: \"regexp\"\n"
                 " --pdfpass <output_warc>          Write PDF records to <output_warc>\n"
                 " --encode-urls                    Encode URLs obtained from WARC records\n"
+                " --paragraph-identification       Add paragraph index in each b64encoded document\n"
                 " -s                               Only output errors\n"
                 " -v                               Verbose output (print trace)\n\n";
         exit(1);
@@ -91,7 +94,9 @@ int main(int argc, char *argv[]) {
     std::unordered_set<std::string> output_files(files_list.begin(), files_list.end());
 
     std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-    WARCPreprocessor warcpproc(options.output, output_files, options.pdf_warc_filename, options.tag_filters_filename, options.tag_filters_invert, options.url_filters_filename, options.multilang, options.encodeURLs);
+    WARCPreprocessor warcpproc(options.output, output_files, options.pdf_warc_filename, options.tag_filters_filename,
+                               options.tag_filters_invert, options.url_filters_filename, options.multilang,
+                               options.encodeURLs, options.paragraph_identification);
     for (const std::string& file : options.warcs){
         warcpproc.process(file);
     }

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -50,7 +50,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
     po::variables_map vm;
     po::store(po::command_line_parser(argc, argv).options(desc).positional(pd).run(), vm);
     if (argc == 1 || vm["help"].as<bool>()) {
-        std::cerr << "Usage: " << argv[0] << " -o <output_folder> [ -f <output_files> ] [ --pdfpass <output_warc> ] [ --tag-filters <filters_file> ] <warc_file>...\n"
+        std::cerr << "Usage: " << argv[0] << " -o <output_folder> [ -f <output_files> ] [ --pdfpass <output_warc> ] [ --paragraph-identification ] [ --tag-filters <filters_file> ] <warc_file>...\n"
                 "\n"
                 "Options:\n"
                 " -o <output_folder>               Output folder, required\n"
@@ -66,7 +66,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
                 "                                  Format: \"regexp\"\n"
                 " --pdfpass <output_warc>          Write PDF records to <output_warc>\n"
                 " --encode-urls                    Encode URLs obtained from WARC records\n"
-                " --paragraph-identification       Add paragraph index in each b64encoded document\n"
+                " --paragraph-identification       Add paragraph index for each sentence extracted from the html\n"
                 " -s                               Only output errors\n"
                 " -v                               Verbose output (print trace)\n\n";
         exit(1);


### PR DESCRIPTION
New feature which identifies paragraphs if flag `--paragraph-identification` is set. It adds an identifier for each extracted paragraph from the HTML before being base64-encoded. If `--paragraph-identification` is set, when base64-decoded, it has to be taken into account that the document has been encoded "twice" (if the text is going to be processes, the text will have to be split and get the first element).

The format is: `<document content><tab><paragraph identifier>`. The paragraph identifier is a number which starts at 0.