### PR TITLE
Add `--jsonl` option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(warc2text)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -DBOOST_LOG_DYN_LINK ${CMAKE_CXX_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif ()
 
-find_package(Boost 1.71 COMPONENTS program_options log log_setup REQUIRED)
+find_package(Boost 1.75 COMPONENTS program_options json log log_setup REQUIRED)
 
 # compile executable into bin/
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ warc2text -o <output_folder> [ -f <output_files> ] [ --pdfpass <output_warc> ]
 * `--encode-urls` Escape non-ascii characters that appear in the record URL with `%dd` encoding.
 * `--multilang` Detect multiple languages in the document, and split the document accordingly. Only supported with CLD2 classifier.
 * `--paragraph-identification` print the paragraph identifier for each sentence extracted from the HTML
-* `--classifier` classifier to use: `cld2` or `fasttext`.
-* `--fasttext-model` path to FastText model for fasttext classifier.
+* `--classifier` classifier to use: `cld2` or `fasttext`. When `fasttext` is used, one also has to specify a model using `--fasttext-model`.
+* `--fasttext-model` path to FastText model for fasttext classifier. Models can be any [FastText language identification model](https://fasttext.cc/docs/en/language-identification.html) such as [OpenLID lid201-model.ftz](https://github.com/laurieburchell/open-lid-dataset#quantised-model)
 * `--tag-filters` file containing filters that are used to eliminate matching documents
 * `--invert-tag-filters` output only documents that match the filter
 * `--url-filters` file containing regular expressions that match urls of documents to eliminate

--- a/README.md
+++ b/README.md
@@ -42,8 +42,12 @@ warc2text -o <output_folder> [ -f <output_files> ] [ --pdfpass <output_warc> ]
           [ --paragraph-identification ] [ --tag-filters <filters_file> ] <warc_file>...
 ```
 * `--output`/`-o` output folder
-* `--files`/`-f` list of output files separated by commas (and without `.gz`); `text` and `url` are always written, while `mime` and `html` are optional
+* `--files`/`-f` list of output files separated by commas (and without `.gz`); Options are `text`,`html`,`url`,`mime`,`file` and `date`. Defaults to `text,url`. See [output](#output).
+* `--jsonl` Produce JSON Lines on stdout instead of writing to files per language.
 * `--pdfpass` WARC file where PDF records will be stored
+* `--robotstxtpass` WARC file where robots.txt related records will be stored
+* `--encode-urls` Escape non-ascii characters that appear in the record URL with `%dd` encoding.
+* `--multilang` Detect multiple languages in the document, and split the document accordingly. Only supported with CLD2 classifier.
 * `--paragraph-identification` print the paragraph identifier for each sentence extracted from the HTML
 * `--classifier` classifier to use: `cld2` or `fasttext`.
 * `--fasttext-model` path to FastText model for fasttext classifier.
@@ -60,6 +64,39 @@ warc2text -o <output_folder> [ -f <output_files> ] [ --pdfpass <output_warc> ]
   URL Filter format is a single regular expression per line.
 
   Lines beginning with `#` and empty lines are ignored. Any invalid filter will raise a warning message, but will not prevent other filters from being read.
+
+## Output
+When used with `--output`/`-o` (with optionally `--files`/`-f`), warc2text will
+produce the following directory structure at the path specified by `--output`:
+
+- `./{lang}/text.gz` will contain the plain text per document as base64 encoded lines. E.g. `gzip -cd en/text.gz | head -n5 | tail -n1 | base64 -d` will give you the 5th document's text.
+- `./{lang}/url.gz` contains [the crawled URL](https://iipc.github.io/warc-specifications/specifications/warc-format/warc-1.1/#warc-target-uri) for each record.
+- `./{lang}/mime.gz` contains the mimetype as reported by the crawled server
+- `./{lang}/html.gz` contains lines of base64 encoded HTML as returned by the server. For ePub, MS Office or ODF files this is the extracted XML.
+- `./{lang}/file.gz` contains the `{filename}:{offset}:{length}` pointer to the warc archive the record was extracted from. `{offset}` and `{length}` are of the compressed data, e.g. `tail -c+{offset} < {filename} | head -c{length} | gzip -cd` will give you the original record.
+- `./{lang}/date.gz` gives you the original crawl date/time as reported by the crawler. [This should be a UTC timestamp](https://iipc.github.io/warc-specifications/specifications/warc-format/warc-1.1/#warc-date-mandatory).
+
+In every file, each line corresponds to the same record. E.g. the fifth line in `text.gz` and fifth line in `url.gz` together give you the text and url for a single record.
+
+The `{lang}` part of the path is determined by the classifier (see `--classifier`) and may be a two-letter or three-letter code depending on the classifier used. See [this list](https://github.com/CLD2Owners/cld2/blob/b56fa78a2fe44ac2851bae5bf4f4693a0644da7b/internal/generated_language.cc#L647-L1262) for CLD2.
+
+When using `--jsonl`, the output is instead a single JSON record per line, with the following keys (always in this order):
+```ts
+{
+  f:  string, # filename of warc file (same as the `{filename}` part in `file.gz`)
+  o:  number, # byte offset of record in warc file (same as `{offset}` in `file.gz`)
+  s:  number, # warc file record size (same as `{size}` in `file.gz`)
+  rs: number, # byte size of record payload (uncompressed)
+  ps: number, # byte size of text only payload (so compare this against `rs` and you should get amount of HTML removed)
+  l:  string, # identified language by classifier
+  u:  string, # url
+  c:  string, # content type as reported by the HTTP response header (or warc record header if that isn't present)
+  ts: string, # crawl date/time as reported by the crawler
+  p:  string, # plain text
+}
+```
+
+More keys might be added in the future (e.g. the raw HTML is not included now) and you should not expect the order of the keys to stay the same between different versions of warc2text.
 
 ## Included dependencies
 HTML Tokenizer by [c-smile](https://www.codeproject.com/Articles/14076/Fast-and-Compact-HTML-XML-Scanner-Tokenizer)

--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -150,7 +150,7 @@ namespace warc2text{
                  {"l", boost::json::string(chunk.first)},
                  {"u", boost::json::string(record.getURL())},
                  {"c", boost::json::string(record.getHTTPcontentType())},
-                 {"t", boost::json::string(chunk.second)},
+                 {"p", boost::json::string(chunk.second)},
             } << "\n";
         }
     }

--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -160,6 +160,7 @@ namespace warc2text{
         out_ << "{"
              << "\"f\":"   << escapeJSON(record.getFilename()) << ","
              << "\"o\":"   << escapeJSON(record.getOffset()) << ","
+             << "\"s\":"   << escapeJSON(record.getSize()) << ","
              << "\"rs\":"  << escapeJSON(record.getPayload().size()) << ","
              << "\"ps\":"  << escapeJSON(record.getPlainText().size()) << ","
              << "\"l\":" << escapeJSON(record.getLanguage()) << ","

--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -93,6 +93,8 @@ namespace warc2text{
             html_file.open(path + "/html.gz");
         if (output_files.count("file"))
             file_file.open(path + "/file.gz");
+        if (output_files.count("date"))
+            date_file.open(path + "/date.gz");
     }
 
     void LangWriter::write(Record const &record, std::string const &chunk) {
@@ -102,6 +104,8 @@ namespace warc2text{
             mime_file.writeLine(record.getHTTPcontentType());
         if (file_file.is_open())
             file_file.writeLine(record.getFilename() + ":" + std::to_string(record.getOffset()) + ":" + std::to_string(record.getSize()));
+        if (date_file.is_open())
+            date_file.writeLine(record.getWARCdate());
         if (html_file.is_open())
             html_file.writeLine(util::encodeBase64(record.getPayload()));
         if (text_file.is_open())
@@ -147,6 +151,7 @@ namespace warc2text{
                  {"l", boost::json::string(chunk.first)},
                  {"u", boost::json::string(record.getURL())},
                  {"c", boost::json::string(record.getHTTPcontentType())},
+                 {"ts", boost::json::string(record.getWARCdate())},
                  {"p", boost::json::string(chunk.second)},
             } << "\n";
         }

--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -9,27 +9,20 @@
 
 namespace warc2text{
 
-    GzipWriter::GzipWriter() {
-        dest = nullptr;
-        compressed = 0;
-        s.zalloc = nullptr;
-        s.zfree = nullptr;
-        s.opaque = nullptr;
-        int ret = deflateInit2(&s, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY);
-        assert(ret == Z_OK);
-        buf = new unsigned char[BUFFER_SIZE];
+    GzipWriter::GzipWriter()
+    : dest(nullptr),
+      buf(new unsigned char[BUFFER_SIZE]) {
+        //
     }
 
     GzipWriter::~GzipWriter() {
-        if (dest) {
-            this->compress("", 0, Z_FINISH);
-            deflateEnd(&s);
-            std::fclose(dest);
-        }
+        if (is_open())
+            close();
         delete[] buf;
     }
 
     void GzipWriter::compress(const char *in, std::size_t size, int flush) {
+        assert(is_open());
         if (size == 0 && flush == Z_NO_FLUSH) return;
         s.avail_in = size;
         s.next_in = (Bytef *) in;
@@ -42,7 +35,7 @@ namespace warc2text{
             s.next_out = buf;
             ret = deflate(&s, flush);
             assert(ret == Z_OK || ret == Z_STREAM_END); // Z_STREAM_END only happens if flush == Z_FINISH
-            compressed = BUFFER_SIZE - s.avail_out;
+            std::size_t compressed = BUFFER_SIZE - s.avail_out;
             //written = std::fwrite(buf, 1, compressed, dest);
             std::fwrite(buf, 1, compressed, dest);
             // TODO error handling
@@ -55,51 +48,64 @@ namespace warc2text{
     void GzipWriter::open(const std::string& filename) {
         dest = std::fopen(filename.c_str(), "wb");
         UTIL_THROW_IF(!dest, util::ErrnoException, "while creating " << filename);
+        s.zalloc = nullptr;
+        s.zfree = nullptr;
+        s.opaque = nullptr;
+        int ret = deflateInit2(&s, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY);
+        assert(ret == Z_OK);
+    }
+
+    void GzipWriter::close() {
+        compress("", 0, Z_FINISH);
+        deflateEnd(&s);
+        std::fclose(dest);
+        dest = nullptr;
     }
 
     void GzipWriter::write(const char* text, std::size_t size) {
-        this->compress(text, size, Z_NO_FLUSH);
+        compress(text, size, Z_NO_FLUSH);
     }
 
     void GzipWriter::writeLine(const char* text, std::size_t size) {
-        this->compress(text, size, Z_NO_FLUSH);
-        this->compress("\n", 1, Z_NO_FLUSH);
+        compress(text, size, Z_NO_FLUSH);
+        compress("\n", 1, Z_NO_FLUSH);
     }
 
     void GzipWriter::writeLine(const std::string& text) {
-        this->compress(text.c_str(), text.size(), Z_NO_FLUSH);
-        this->compress("\n", 1, Z_NO_FLUSH);
+        compress(text.c_str(), text.size(), Z_NO_FLUSH);
+        compress("\n", 1, Z_NO_FLUSH);
     }
 
     bool GzipWriter::is_open(){
         return dest != nullptr;
     }
 
-    void BilangWriter::write(const std::string& lang, const std::string& b64text, const std::string& url, const std::string& mime, const std::string& b64html, const std::string& file) {
-        GzipWriter* gzurl = &url_files[lang];
-        GzipWriter* gztext = &text_files[lang];
-        GzipWriter* gzmime = nullptr;
-        GzipWriter* gzhtml = nullptr;
-        GzipWriter* gzfile = nullptr;
-        if (output_files.count("mime") == 1) gzmime = &(mime_files[lang]);
-        if (output_files.count("html") == 1) gzhtml = &(html_files[lang]);
-        if (output_files.count("file") == 1) gzfile = &(file_files[lang]);
-        if (!gzurl->is_open()) {
-            // if one file does not exist, the rest shouldn't either
-            std::string path = folder + "/" + lang;
-            util::createDirectories(path);
-            gzurl->open(path + "/url.gz");
-            gztext->open(path + "/text.gz");
-            if (gzmime != nullptr) gzmime->open(path + "/mime.gz");
-            if (gzhtml != nullptr) gzhtml->open(path + "/html.gz");
-            if (gzfile != nullptr) gzfile->open(path + "/file.gz");
-        }
+    LangWriter::LangWriter(const std::string& path, const std::unordered_set<std::string>& output_files) {
+        util::createDirectories(path);
 
-        gzurl->writeLine(url);
-        gztext->writeLine(b64text);
-        if (gzmime != nullptr) gzmime->writeLine(mime);
-        if (gzhtml != nullptr) gzhtml->writeLine(b64html);
-        if (gzfile != nullptr) gzfile->writeLine(file);
+        if (output_files.count("url"))
+            url_file.open(path + "/url.gz");
+        if (output_files.count("text"))
+            text_file.open(path + "/text.gz");
+        if (output_files.count("mime"))
+            mime_file.open(path + "/mime.gz");
+        if (output_files.count("html"))
+            html_file.open(path + "/html.gz");
+        if (output_files.count("file"))
+            file_file.open(path + "/file.gz");
+    }
+
+    void LangWriter::write(Record const &record, std::string const &chunk) {
+        if (url_file.is_open())
+            url_file.writeLine(record.getURL());
+        if (mime_file.is_open())
+            mime_file.writeLine(record.getHTTPcontentType());
+        if (file_file.is_open())
+            file_file.writeLine(record.getFilename() + ":" + std::to_string(record.getOffset()) + ":" + std::to_string(record.getSize()));
+        if (html_file.is_open())
+            html_file.writeLine(util::encodeBase64(record.getPayload()));
+        if (text_file.is_open())
+            text_file.writeLine(util::encodeBase64(chunk));
     }
 
     std::string get_paragraph_id(const std::string& text) {
@@ -118,23 +124,14 @@ namespace warc2text{
     }
 
     void BilangWriter::write(const Record& record, bool paragraph_identification) {
-        std::string base64text;
-        std::string base64html;
-
-        if (output_files.count("html") == 1)
-            util::encodeBase64(record.getPayload(), base64html);
-
-        std::string file = record.getFilename() + ":" + std::to_string(record.getOffset()) + ":" + std::to_string(record.getSize());
-
         for (const auto& it : record.getTextByLangs()) {
-            std::string payload = it.second;
+            std::string chunk = it.second;
 
-            if (paragraph_identification) {
-                payload = get_paragraph_id(payload);
-            }
+            if (paragraph_identification)
+                chunk = get_paragraph_id(chunk);
 
-            util::encodeBase64(payload, base64text);
-            this->write(it.first, base64text, record.getURL(), record.getHTTPcontentType(), base64html, file);
+            auto writer_it = writers.try_emplace(it.first, folder + "/" + it.first, output_files);
+            writer_it.first->second.write(record, chunk);
         }
     }
 

--- a/src/bilangwriter.hh
+++ b/src/bilangwriter.hh
@@ -41,26 +41,19 @@ namespace warc2text {
             std::unordered_map<std::string, GzipWriter> mime_files;
             std::unordered_map<std::string, GzipWriter> text_files;
             std::unordered_map<std::string, GzipWriter> html_files;
+            std::unordered_map<std::string, GzipWriter> file_files;
             std::unordered_set<std::string> output_files;
 
-            void write(const std::string& lang, const std::string& b64text, const std::string& url, const std::string& mime, const std::string& b64html);
+            void write(const std::string& lang, const std::string& b64text, const std::string& url, const std::string& mime, const std::string& b64html, const std::string& file);
 
         public:
-            explicit BilangWriter(const std::string& folder) :
+            explicit BilangWriter(const std::string& folder, const std::unordered_set<std::string>& output_files = {}) :
                 folder(folder),
                 url_files(),
                 mime_files(),
                 text_files(),
                 html_files(),
-                output_files({}) // url and text are mandatory regardless
-            {};
-
-            explicit BilangWriter(const std::string& folder, const std::unordered_set<std::string>& output_files) :
-                folder(folder),
-                url_files(),
-                mime_files(),
-                text_files(),
-                html_files(),
+                file_files(),
                 output_files(output_files)
             {};
 

--- a/src/bilangwriter.hh
+++ b/src/bilangwriter.hh
@@ -3,10 +3,17 @@
 
 #include <unordered_map>
 #include <unordered_set>
+#include <ostream>
 #include "record.hh"
 #include "zlib.h"
 
 namespace warc2text {
+
+    class RecordWriter {
+    public:
+        virtual void write(const Record& record, bool multilang = false, bool paragraph_identification = false) = 0;
+        virtual ~RecordWriter() = default;
+    };
 
     class GzipWriter {
         private:
@@ -27,7 +34,7 @@ namespace warc2text {
             static const std::size_t BUFFER_SIZE = 4096;
     };
 
-    class BilangWriter {
+    class BilangWriter : public RecordWriter {
         private:
             std::string folder;
             std::unordered_map<std::string, GzipWriter> url_files;
@@ -57,11 +64,18 @@ namespace warc2text {
                 output_files(output_files)
             {};
 
-            void write(const Record& record, bool multilang = false, bool paragraph_identification = false);
+            virtual void write(const Record& record, bool multilang = false, bool paragraph_identification = false);
 
     };
 
+    class JSONLinesWriter : public RecordWriter {
+        private:
+            std::ostream &out_;
+        public:
+            explicit JSONLinesWriter(std::ostream &out) : out_(out) {};
 
+            virtual void write(const Record& record, bool multilang = false, bool paragraph_identification = false);
+    };
 }
 
 #endif

--- a/src/bilangwriter.hh
+++ b/src/bilangwriter.hh
@@ -51,6 +51,7 @@ namespace warc2text {
             GzipWriter text_file;
             GzipWriter html_file;
             GzipWriter file_file;
+            GzipWriter date_file;
         public:
             LangWriter(const std::string& folder, const std::unordered_set<std::string>& output_files);
             void write(const Record& record, const std::string &chunk);

--- a/src/bilangwriter.hh
+++ b/src/bilangwriter.hh
@@ -9,24 +9,31 @@
 
 namespace warc2text {
 
+    /**
+     * Generic interface for writing records to some form of output.
+     */
     class RecordWriter {
     public:
         virtual void write(const Record& record, bool paragraph_identification = false) = 0;
         virtual ~RecordWriter() = default;
     };
 
+    /**
+     * Writer used by BilangWriter to write a single compressed file
+     * (i.e. a column for a specific language)
+     */
     class GzipWriter {
         private:
             FILE* dest;
             z_stream s{};
             unsigned char* buf;
-            std::size_t compressed;
             void compress(const char* in, std::size_t size, int flush);
 
         public:
             GzipWriter();
             ~GzipWriter();
             void open(const std::string& filename);
+            void close();
             void write(const char* text, std::size_t size);
             void writeLine(const char* text, std::size_t size);
             void writeLine(const std::string& text);
@@ -34,31 +41,35 @@ namespace warc2text {
             static const std::size_t BUFFER_SIZE = 4096;
     };
 
+    /**
+     * Writes records to a specific folder for a specific language.
+     */
+    class LangWriter {
+        private:
+            GzipWriter url_file;
+            GzipWriter mime_file;
+            GzipWriter text_file;
+            GzipWriter html_file;
+            GzipWriter file_file;
+        public:
+            LangWriter(const std::string& folder, const std::unordered_set<std::string>& output_files);
+            void write(const Record& record, const std::string &chunk);
+    };
+
     class BilangWriter : public RecordWriter {
         private:
             std::string folder;
-            std::unordered_map<std::string, GzipWriter> url_files;
-            std::unordered_map<std::string, GzipWriter> mime_files;
-            std::unordered_map<std::string, GzipWriter> text_files;
-            std::unordered_map<std::string, GzipWriter> html_files;
-            std::unordered_map<std::string, GzipWriter> file_files;
             std::unordered_set<std::string> output_files;
-
-            void write(const std::string& lang, const std::string& b64text, const std::string& url, const std::string& mime, const std::string& b64html, const std::string& file);
-
+            std::unordered_map<std::string, LangWriter> writers;
         public:
-            explicit BilangWriter(const std::string& folder, const std::unordered_set<std::string>& output_files = {}) :
-                folder(folder),
-                url_files(),
-                mime_files(),
-                text_files(),
-                html_files(),
-                file_files(),
-                output_files(output_files)
-            {};
+            BilangWriter(const std::string& folder, const std::unordered_set<std::string>& output_files = {})
+            : folder(folder)
+            , output_files(output_files)
+            {
+                //
+            };
 
             virtual void write(const Record& record, bool paragraph_identification = false);
-
     };
 
     class JSONLinesWriter : public RecordWriter {

--- a/src/record.cc
+++ b/src/record.cc
@@ -34,7 +34,10 @@ namespace warc2text {
         return header_end + 4;
     }
 
-    Record::Record(const std::string& content) {
+    Record::Record(const std::string& content, const std::string& filename, std::size_t offset) :
+        filename(filename),
+        offset(offset)
+    {
         std::string line;
         std::size_t last_pos = 0, payload_start = 0;
         std::size_t pos = content.find("WARC/1.0\r\n");
@@ -306,5 +309,4 @@ namespace warc2text {
     void Record::encodeURL() {
         url = util::encodeURLs(url);
     }
-
 } // warc2text

--- a/src/record.cc
+++ b/src/record.cc
@@ -34,8 +34,9 @@ namespace warc2text {
         return header_end + 4;
     }
 
-    Record::Record(const std::string& content, const std::string& filename, std::size_t offset) :
+    Record::Record(const std::string& content, const std::string& filename, std::size_t size, std::size_t offset) :
         filename(filename),
+        size(size),
         offset(offset)
     {
         std::string line;

--- a/src/record.cc
+++ b/src/record.cc
@@ -279,10 +279,6 @@ namespace warc2text {
         return plaintext;
     }
 
-    const std::string& Record::getLanguage() const {
-        return language;
-    }
-
     const std::string& Record::getURL() const {
         return url;
     }

--- a/src/record.cc
+++ b/src/record.cc
@@ -65,10 +65,11 @@ namespace warc2text {
         if (header.count("warc-target-uri") == 1) {
             // respect the original casing
             url = header["warc-target-uri"];
-        }
 
-        if (!url.empty() && url[0] == '<' && url[url.size()-1] == '>')
-            url = url.substr(1, url.size()-2);
+            // Remove any "<" and ">" wrappings from the URL
+            if (!url.empty() && url[0] == '<' && url[url.size()-1] == '>')
+                url = url.substr(1, url.size()-2);
+        }
 
         if (header.count("content-type") == 1) {
             WARCcontentType = header["content-type"];
@@ -80,7 +81,7 @@ namespace warc2text {
         }
 
         payload_start = last_pos;
-        if (header["warc-type"] == "response") {
+        if (recordType == "response") {
             // parse HTTP header
             pos = content.find("HTTP/1.", last_pos);
             if (pos == last_pos) { // found HTTP header

--- a/src/record.cc
+++ b/src/record.cc
@@ -75,6 +75,10 @@ namespace warc2text {
             util::toLower(WARCcontentType);
         }
 
+        if (header.count("warc-date") == 1) {
+            WARCdate = header["warc-date"];
+        }
+
         payload_start = last_pos;
         if (header["warc-type"] == "response") {
             // parse HTTP header
@@ -285,6 +289,10 @@ namespace warc2text {
 
     const std::string& Record::getRecordType() const {
         return recordType;
+    }
+
+    const std::string& Record::getWARCdate() const {
+        return WARCdate;
     }
 
     const std::string& Record::getWARCcontentType() const {

--- a/src/record.hh
+++ b/src/record.hh
@@ -14,9 +14,7 @@
 namespace warc2text {
     class Record {
     public:
-        Record() {};
-
-        explicit Record(const std::string& content);
+        Record(const std::string& content, const std::string &filename, std::size_t offset);
         const std::string& getHeaderProperty(const std::string& property) const;
         bool headerExists(const std::string& property) const;
 
@@ -34,6 +32,14 @@ namespace warc2text {
         bool isBroaderDocumentFormat() const;
         bool isTextFormat() const;
 
+        inline const std::string& getFilename() const {
+            return filename;
+        }
+
+        inline std::size_t getOffset() const {
+            return offset;
+        }
+        
         const std::unordered_map<std::string, std::string>& getTextByLangs() const;
 
         int cleanPayload();
@@ -46,6 +52,9 @@ namespace warc2text {
         void encodeURL();
 
     private:
+        const std::string &filename;
+        std::size_t offset;
+
         std::unordered_map<std::string, std::string> header;
         std::unordered_map<std::string, std::string> HTTPheader;
         std::string payload;

--- a/src/record.hh
+++ b/src/record.hh
@@ -23,7 +23,6 @@ namespace warc2text {
 
         const std::string& getPayload() const;
         const std::string& getPlainText() const;
-        const std::string& getLanguage() const;
         const std::string& getURL() const;
         const std::string& getRecordType() const;
         const std::string& getWARCcontentType() const;

--- a/src/record.hh
+++ b/src/record.hh
@@ -26,6 +26,7 @@ namespace warc2text {
         const std::string& getURL() const;
         const std::string& getRecordType() const;
         const std::string& getWARCcontentType() const;
+        const std::string& getWARCdate() const;
         const std::string& getHTTPcontentType() const;
         const std::string& getCharset() const;
         bool isBroaderDocumentFormat() const;
@@ -70,6 +71,7 @@ namespace warc2text {
         // these are present in the headers, but it's convenient to have them apart also
         std::string recordType;
         std::string WARCcontentType;
+        std::string WARCdate;
         std::string cleanHTTPcontentType;
         std::string charset;
         std::string url;

--- a/src/record.hh
+++ b/src/record.hh
@@ -14,7 +14,7 @@
 namespace warc2text {
     class Record {
     public:
-        Record(const std::string& content, const std::string &filename, std::size_t offset);
+        Record(const std::string& content, const std::string &filename, std::size_t size, std::size_t offset);
         const std::string& getHeaderProperty(const std::string& property) const;
         bool headerExists(const std::string& property) const;
 
@@ -36,6 +36,10 @@ namespace warc2text {
             return filename;
         }
 
+        inline std::size_t getSize() const {
+            return size;
+        }
+
         inline std::size_t getOffset() const {
             return offset;
         }
@@ -53,7 +57,8 @@ namespace warc2text {
 
     private:
         const std::string &filename;
-        std::size_t offset;
+        std::size_t size; // compressed record length in WARC
+        std::size_t offset; // byte offset of start of record in WARC
 
         std::unordered_map<std::string, std::string> header;
         std::unordered_map<std::string, std::string> HTTPheader;

--- a/src/util.cc
+++ b/src/util.cc
@@ -82,12 +82,10 @@ namespace util {
         return boost::locale::conv::to_utf<char>(text, charset);
     }
 
-    void encodeBase64(const std::string& original, std::string& base64){
-        preprocess::base64_encode(original, base64);
-    }
-
-    void decodeBase64(const std::string& base64, std::string& output){
-        preprocess::base64_decode(base64, output);
+    std::string encodeBase64(const std::string &original) {
+        std::string out;
+        preprocess::base64_encode(original, out);
+        return out;
     }
 
     void readTagFiltersRegex(const std::string& filename, umap_tag_filters_regex& filters) {

--- a/src/util.hh
+++ b/src/util.hh
@@ -25,9 +25,7 @@ namespace util {
     std::string toUTF8 (const std::string& text, const std::string& charset);
     std::string toUTF8 (const char* text, const std::string& charset);
 
-    void encodeBase64(const std::string& original, std::string& base64);
-
-    void decodeBase64(const std::string& base64, std::string& output);
+    std::string encodeBase64(const std::string& original);
 
     const std::string reserved_chars_url("!#$&'()*+,/:;=?[]");
     std::string encodeURLs(const std::string& url);

--- a/src/warcpreprocessor.cc
+++ b/src/warcpreprocessor.cc
@@ -58,21 +58,25 @@ namespace warc2text {
         BOOST_LOG_TRIVIAL(info) << "Processing " << filename;
         WARCReader reader(filename);
 
-        std::size_t offset;
         std::string content;
-        bool done = false;
         int n_langs = 0;
 
         bool pdfpass = !pdf_warc_filename.empty();
         WARCWriter pdf_warc_writer;
 
-        while (!done) {
-            offset = reader.tell();
-            done = !reader.getRecord(content);
-            if (done or content.empty())
+        while (true) {
+            std::size_t offset = reader.tell();
+            std::size_t size = reader.getRecord(content);
+            
+            // No more records (EOF or failure to inflate)
+            if (size == 0)
+                break;
+
+            // Skipped record (i.e. larger than max_size)
+            if (content.empty())
                 continue;
 
-            Record record(content, filename, offset);
+            Record record(content, filename, size, offset);
             if (record.getPayload().empty())
                 continue;
 

--- a/src/warcpreprocessor.cc
+++ b/src/warcpreprocessor.cc
@@ -1,5 +1,6 @@
 
 #include <iostream>
+#include "src/bilangwriter.hh"
 #include "warcpreprocessor.hh"
 #include "zipreader.hh"
 #include "util/compress.hh"
@@ -10,10 +11,11 @@ namespace warc2text {
     const std::unordered_set<std::string> WARCPreprocessor::removeExtensions = {".jpg", ".jpeg", ".gif", ".png", ".css", ".js", ".mp3",
                                                                                 ".mp4", ".flv", ".wmv", ".gz", ".zip", ".rar" };
 
-    WARCPreprocessor::WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files,
+    WARCPreprocessor::WARCPreprocessor(RecordWriter &writer,
                                        const std::string& pdf_warc_filename, const std::string& tagFiltersFile, bool invert,
                                        const std::string& urlFiltersFile, bool multilang, bool encodeURLs,
-                                       bool paragraph_identification, bool jsonl) :
+                                       bool paragraph_identification) :
+        writer(writer),
         totalRecords(0),
         textRecords(0),
         langRecords(0),
@@ -26,13 +28,6 @@ namespace warc2text {
         multilang(multilang),
         encodeURLs(encodeURLs),
         paragraph_identification(paragraph_identification) {
-            if (jsonl)
-                writer = std::make_unique<JSONLinesWriter>(std::cout);
-            else if (!output_files.empty())
-                writer = std::make_unique<BilangWriter>(outputFolder, output_files);
-            else
-                std::exit(1);
-
             if (!tagFiltersFile.empty())
                 util::readTagFiltersRegex(tagFiltersFile, tagFilters);
 
@@ -170,7 +165,7 @@ namespace warc2text {
 
             langRecords += n_langs;
 
-            writer->write(record, multilang, paragraph_identification);
+            writer.write(record, multilang, paragraph_identification);
         }
         pdf_warc_writer.close();
     }

--- a/src/warcpreprocessor.hh
+++ b/src/warcpreprocessor.hh
@@ -5,6 +5,7 @@
 #include "warcreader.hh"
 #include "bilangwriter.hh"
 #include "util.hh"
+#include <memory>
 #include <string>
 #include <unordered_set>
 #include <boost/regex.hpp>
@@ -24,7 +25,7 @@ namespace warc2text {
 
     class WARCPreprocessor {
         private:
-            BilangWriter writer;
+            std::unique_ptr<RecordWriter> writer;
             unsigned int totalRecords;
             unsigned int textRecords;
             unsigned int langRecords;
@@ -46,7 +47,7 @@ namespace warc2text {
             explicit WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files = {},
                                       const std::string& pdf_warc_filename = "", const std::string& tagFiltersFile = "",
                                       bool invert = false, const std::string& urlFiltersFile = "", bool multilang = false,
-                                      bool encodeURLs = false, bool paragraph_identification = false);
+                                      bool encodeURLs = false, bool paragraph_identification = false, bool jsonl = false);
             void process(const std::string &filename);
             void printStatistics() const;
     };

--- a/src/warcpreprocessor.hh
+++ b/src/warcpreprocessor.hh
@@ -25,7 +25,7 @@ namespace warc2text {
 
     class WARCPreprocessor {
         private:
-            std::unique_ptr<RecordWriter> writer;
+            RecordWriter &writer;
             unsigned int totalRecords;
             unsigned int textRecords;
             unsigned int langRecords;
@@ -44,10 +44,10 @@ namespace warc2text {
             bool URLfilter(const std::string& url);
 
         public:
-            explicit WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files = {},
+            explicit WARCPreprocessor(RecordWriter &writer,
                                       const std::string& pdf_warc_filename = "", const std::string& tagFiltersFile = "",
                                       bool invert = false, const std::string& urlFiltersFile = "", bool multilang = false,
-                                      bool encodeURLs = false, bool paragraph_identification = false, bool jsonl = false);
+                                      bool encodeURLs = false, bool paragraph_identification = false);
             void process(const std::string &filename);
             void printStatistics() const;
     };

--- a/src/warcreader.cc
+++ b/src/warcreader.cc
@@ -100,4 +100,8 @@ namespace warc2text {
         return len;
     }
 
+    std::size_t WARCReader::tell() const {
+        return std::ftell(file) - s.avail_in;
+    }
+
 } // warc2text

--- a/src/warcreader.hh
+++ b/src/warcreader.hh
@@ -2,7 +2,9 @@
 #define WARC2TEXT_WARCREADER_HH
 
 #include "zlib.h"
+#include <array>
 #include <string>
+#include "util/file.hh"
 
 namespace warc2text {
     class WARCReader {
@@ -13,12 +15,12 @@ namespace warc2text {
             std::size_t tell() const;
             ~WARCReader();
         private:
-            std::FILE* file;
+            util::scoped_FILE file;
             std::string warc_filename;
             z_stream s{};
             static const std::size_t BUFFER_SIZE = 4096;
-            uint8_t* buf;
-            uint8_t* scratch;
+            std::array<uint8_t, BUFFER_SIZE> buf;
+            std::array<uint8_t, BUFFER_SIZE> scratch;
 
             void openFile(const std::string& filename);
             void closeFile();

--- a/src/warcreader.hh
+++ b/src/warcreader.hh
@@ -10,6 +10,7 @@ namespace warc2text {
             WARCReader();
             explicit WARCReader(const std::string& filename);
             bool getRecord(std::string& out, std::size_t max_size = 1024*1024*20); //20MB
+            std::size_t tell() const;
             ~WARCReader();
         private:
             std::FILE* file;

--- a/src/warcreader.hh
+++ b/src/warcreader.hh
@@ -9,7 +9,7 @@ namespace warc2text {
         public:
             WARCReader();
             explicit WARCReader(const std::string& filename);
-            bool getRecord(std::string& out, std::size_t max_size = 1024*1024*20); //20MB
+            std::size_t getRecord(std::string& out, std::size_t max_size = 1024*1024*20); //20MB
             std::size_t tell() const;
             ~WARCReader();
         private:

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -64,7 +64,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
                 " -o <output_folder>               Output folder, required\n"
                 " -f <output_files>                List of output files separated by commas\n"
                 "                                  Default (mandatory): \"url,text\"\n"
-                "                                  Optional values: \"mime,html\"\n"
+                "                                  Optional values: \"mime,html,file\"\n"
                 " --classifier                     Classifier to use: cld2 or fasttext\n"
                 " --fasttext-model <model_file>    Path to FastText model for fasttext classifier\n"
                 " --multilang                      Detect multiple languages in documents (up to 3),\n"

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -37,7 +37,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
     desc.add_options()
         ("help,h", po::bool_switch(), "Show this help message")
         ("output,o", po::value(&out.output)->default_value("."), "Output folder")
-        ("files,f", po::value(&out.files)->default_value("url,token"), "List of output files separated by commas. Default (mandatory files): 'url,text'. Optional: 'mime,html'")
+        ("files,f", po::value(&out.files)->default_value("url,text"), "List of output files separated by commas. Default: 'url,text'. Optional: 'mime,html,file'")
         ("input,i", po::value(&out.warcs)->multitoken(), "Input WARC file name(s)")
         ("tag-filters", po::value(&out.tag_filters_filename), "Plain text file containing tag filters")
         ("invert-tag-filters", po::bool_switch(&out.tag_filters_invert)->default_value(false), "Invert tag filter application")

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -57,7 +57,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
                 " -o <output_folder>               Output folder, required\n"
                 " -f <output_files>                List of output files separated by commas\n"
                 "                                  Default (mandatory): \"url,text\"\n"
-                "                                  Optional values: \"mime,html,file\"\n"
+                "                                  Optional values: \"mime,html,file,date\"\n"
                 " --classifier                     Classifier to use: cld2 or fasttext\n"
                 " --fasttext-model <model_file>    Path to FastText model for fasttext classifier\n"
                 " --multilang                      Detect multiple languages in documents (up to 3),\n"

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -25,6 +25,7 @@ struct Options {
     std::string url_filters_filename;
     bool multilang{};
     bool encodeURLs{};
+    bool jsonl{};
 };
 
 void parseArgs(int argc, char *argv[], Options& out) {
@@ -43,6 +44,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
         ("verbose,v", po::bool_switch(&out.verbose)->default_value(false), "Verbosity level")
         ("silent,s", po::bool_switch(&out.silent)->default_value(false))
         ("multilang", po::bool_switch(&out.multilang)->default_value(false), "Detect multiple languages in a single record")
+        ("jsonl", po::bool_switch(&out.jsonl)->default_value(false), "Output jsonl to stdout")
         ("encode-urls", po::bool_switch(&out.encodeURLs)->default_value(false), "Encode URLs obtained from WARC records");
 
     po::positional_options_description pd;
@@ -69,6 +71,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
                 " --encode-urls                    Encode URLs obtained from WARC records\n"
                 " --paragraph-identification       Add paragraph index for each sentence extracted from the html\n"
                 " -s                               Only output errors\n"
+                " --jsonl                          Write JSONLines to stdout\n"
                 " -v                               Verbose output (print trace)\n\n";
         exit(1);
     }
@@ -97,7 +100,7 @@ int main(int argc, char *argv[]) {
     std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
     WARCPreprocessor warcpproc(options.output, output_files, options.pdf_warc_filename, options.tag_filters_filename,
                                options.tag_filters_invert, options.url_filters_filename, options.multilang,
-                               options.encodeURLs, options.paragraph_identification);
+                               options.encodeURLs, options.paragraph_identification, options.jsonl);
     for (const std::string& file : options.warcs){
         warcpproc.process(file);
     }

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -119,6 +119,9 @@ int main(int argc, char *argv[]) {
         if (options.multilang) {
             BOOST_LOG_TRIVIAL(error) << "FastText classifier doesn't do multilang at the moment";
             abort();
+        } else if (options.fasttext_model.empty()) {
+            BOOST_LOG_TRIVIAL(error) << "No FastText language identification model specified. Use --fasttext-model";
+            abort();
         } else {
             detector.reset(new FastTextDetector(options.fasttext_model));
         }


### PR DESCRIPTION
This is mostly to do some metadata analysis of the warcs, but could be a starting point for #34 as well.

For metadata I'm considering trying out [writing to parquet directly](https://arrow.apache.org/docs/cpp/parquet.html). But since warc2text is run in parallel we'd still need to merge parquet files together before doing any analysis. So maybe jsonl is sufficient for this stage. And then we ingest all of those together into a massive parquet file for queries later.

Current output: each line contains a JSON object that consists of:
- `f`: filename of warc file
- `o`: byte offset of record in warc file
- `s`: warc file record size
- `rs`: byte size of record payload (uncompressed)
- `ps`: byte size of text only payload (so compare this against `rs` and you should get amount of HTML removed)
- `l`: identified language by classifier
- `u`: url
- `c`: content type as reported by the HTTP response header (or warc record header if that isn't present)
- `p`: plain text

Todo:
- [x] `ts`: crawl date as found in the record header (no date normalisation or anything)
- [x] ~~`pt`: per paragraph/line in `p` the most nested tag it was found in:
Should this be an array of strings? Or a string separated by newlines to match `p`?~~
- [ ] ~~`pi`: paragraph identifiers as normally produced by `get_paragraph_id()`
Same question as for `pt`, or even just keep this function as-is and add the paragraph identifiers inside `p` which is a real mess but might be easiest for compatibility?~~
Moving these things to #46.

I also want to make these new columns available to the original bitext output as possible arguments for `-f`.

`--multilang` is also supported for the CLD2 classifier. In that case you'd get multiple json lines per record, one for each identified language. The attributes that relate to the record itself will be duplicated, only `p`, `ps` and `l` differ.

Usage:
```
> ll *.warc.gz
 Size Name
1.1Gi CC-MAIN-20221126080725-20221126110725-00000.warc.gz
1.1Gi WIDE-20171021194807-00260.warc.gz

> bin/warc2text --jsonl *.warc.gz | pigz -9c > metadata.jsonl.gz
[2023-02-17 14:41:02.338945] [info] Processing CC-MAIN-20221126080725-20221126110725-00000.warc.gz
[2023-02-17 14:42:02.002268] [info] Processing WIDE-20171021194807-00260.warc.gz
[2023-02-17 14:42:13.112524] [info] total records: 46660
[2023-02-17 14:42:13.112559] [info] text records: 44405
[2023-02-17 14:42:13.112567] [info] lang records: 40914
[2023-02-17 14:42:13.112574] [info] total bytes: 1456844861
[2023-02-17 14:42:13.112580] [info] text bytes: 328455828
[2023-02-17 14:42:13.112587] [info] lang bytes: 285338976
[2023-02-17 14:42:13.112593] [info] elapsed: 0h1m10s

> ll metadata.jsonl.gz
 Size Name
2.1Mi metadata.jsonl.gz
```
So 2Gb of warc yields about 2Mb of jsonlines.

Getting actual metadata from it:
```
> pigz -cd metadata.jsonl.gz | jq --raw-output .u | head
http://0337.maymay520.com/V4/?AID=164332&FID=1782326&WEBID=AVSHOW
http://064.ehiroba.jp/shopdetail/000000000660/ct91/page2/order/
http://095160170158.vectranet.pl/wiadomosci/item/12047-obchody-czerwca-76-z-rekomendacja-komisji-kultury
http://1118.cctv.com/2019/12/30/VIDErVoqOYK0GveK5J2BaDvq191230.shtml
http://114hzw.com/zhanhuipaiqi/industry/jiajujiaji/
http://120rcw.com/about/jinjia.html
http://123nu.dk/lystfiskeri/forum/registration_rules.asp?FID=0&SID=3cae74fcfz339af2f3f86321e46511e3
http://123stopfire.com/Fra/Fr_p1_01.html
http://1368.info/soi-cau-3-cang/
http://1801202223.djtom.cz/%D9%8A%D9%85%D9%83%D9%86-%D8%A3-%D9%8A%D9%83%D9%88%D9%86-%D9%86%D8%B8%D8%B1%D8%A7.html/
```
