### PR TITLE
Add fasttext as an option alongside cld2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = cld2
 	url = https://github.com/bitextor/cld2.git
     ignore = dirty
+[submodule "fasttext"]
+	path = fasttext
+	url = https://github.com/kpuatfb/fastText.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project(warc2text)
 set(CMAKE_CXX_STANDARD 17)
 
 
+set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3")
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -DBOOST_LOG_DYN_LINK ${CMAKE_CXX_FLAGS}")
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I /usr/local/opt/icu4c/include")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(warc2text)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -DBOOST_LOG_DYN_LINK ${CMAKE_CXX_FLAGS}")
@@ -41,10 +41,12 @@ if (NOT SKIP_PREPROCESS_BUILD)
 endif()
 
 target_include_directories(warc2text_lib PUBLIC ${PREPROCESS_PATH})
+target_include_directories(warc2text_lib PRIVATE fasttext/src)
 #
 
 # add libcld2.so
 add_subdirectory(cld2)
+add_subdirectory(fasttext)
 #
 
 # define executables
@@ -53,6 +55,7 @@ target_link_libraries(warc2text
     warc2text_lib
     ${Boost_LIBRARIES}
     cld2_full
+    fasttext-static
 )
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ target_include_directories(warc2text_lib PRIVATE fasttext/src)
 
 # add libcld2.so
 add_subdirectory(cld2)
-add_subdirectory(fasttext)
+add_subdirectory(fasttext EXCLUDE_FROM_ALL)
 #
 
 # define executables

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ warc2text -o <output_folder> [ -f <output_files> ] [ --pdfpass <output_warc> ]
 * `--files`/`-f` list of output files separated by commas (and without `.gz`); `text` and `url` are always written, while `mime` and `html` are optional
 * `--pdfpass` WARC file where PDF records will be stored
 * `--paragraph-identification` print the paragraph identifier for each sentence extracted from the HTML
+* `--classifier` classifier to use: `cld2` or `fasttext`.
+* `--fasttext-model` path to FastText model for fasttext classifier.
 * `--tag-filters` file containing filters that are used to eliminate matching documents
 * `--invert-tag-filters` output only documents that match the filter
 * `--url-filters` file containing regular expressions that match urls of documents to eliminate

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=/your/prefix/path ..
 # cmake .. -DCMAKE_BUILD_TYPE=Debug # for debug
+# cmake .. -DICU_ROOT_DIR=(brew --prefix icu4c)/lib # for macOS
 make -j
 make install
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ make install
 ```
 
 ## Usage
+
+**note:** for warcs with many languages you might hit the open file limit quite quickly. It is therefore advised to increase it, e.g. `ulimit -n 8192`.
+
 ```
 warc2text -o <output_folder> [ -f <output_files> ] [ --pdfpass <output_warc> ]
           [ --paragraph-identification ] [ --tag-filters <filters_file> ] <warc_file>...

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(warc2text_lib
     warcreader.cc
     record.cc
     html.cc
+    lang.cc
     lang_cld2.cc
     lang_fasttext.cc
     util.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,8 @@ add_library(warc2text_lib
     warcreader.cc
     record.cc
     html.cc
-    lang.cc
+    lang_cld2.cc
+    lang_fasttext.cc
     util.cc
     bilangwriter.cc
     xh_scanner.cc

--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -110,39 +110,22 @@ namespace warc2text{
         return result;
     }
 
-    void BilangWriter::write(const Record& record, bool multilang, bool paragraph_identification) {
+    void BilangWriter::write(const Record& record, bool paragraph_identification) {
         std::string base64text;
         std::string base64html;
 
-        if (multilang) {
+        if (output_files.count("html") == 1)
+            util::encodeBase64(record.getPayload(), base64html);
 
-            if (output_files.count("html") == 1)
-                util::encodeBase64(record.getPayload(), base64html);
-
-            for (const auto& it : record.getTextByLangs()) {
-                std::string payload = it.second;
-
-                if (paragraph_identification) {
-                    payload = get_paragraph_id(payload);
-                }
-
-                util::encodeBase64(payload, base64text);
-                this->write(it.first, base64text, record.getURL(), record.getHTTPcontentType(), base64html);
-            }
-
-        } else {
-            std::string payload = record.getPlainText();
+        for (const auto& it : record.getTextByLangs()) {
+            std::string payload = it.second;
 
             if (paragraph_identification) {
                 payload = get_paragraph_id(payload);
             }
 
             util::encodeBase64(payload, base64text);
-
-            if (output_files.count("html") == 1)
-                util::encodeBase64(record.getPayload(), base64html);
-
-            this->write(record.getLanguage(), base64text, record.getURL(), record.getHTTPcontentType(), base64html);
+            this->write(it.first, base64text, record.getURL(), record.getHTTPcontentType(), base64html);
         }
     }
 

--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -1,5 +1,6 @@
 #include "bilangwriter.hh"
 #include "util.hh"
+#include "util/exception.hh"
 #include <cassert>
 #include <string>
 
@@ -50,6 +51,7 @@ namespace warc2text{
 
     void GzipWriter::open(const std::string& filename) {
         dest = std::fopen(filename.c_str(), "wb");
+        UTIL_THROW_IF(!dest, util::ErrnoException, "while creating " << filename);
     }
 
     void GzipWriter::write(const char* text, std::size_t size) {

--- a/src/bilangwriter.hh
+++ b/src/bilangwriter.hh
@@ -57,7 +57,7 @@ namespace warc2text {
                 output_files(output_files)
             {};
 
-            void write(const Record& record, bool multilang = false, bool paragraph_identification = false);
+            void write(const Record& record, bool paragraph_identification = false);
 
     };
 

--- a/src/lang.cc
+++ b/src/lang.cc
@@ -1,0 +1,7 @@
+#include "lang.hh"
+
+namespace warc2text {
+	
+const std::string LanguageDetector::kUnknownLanguageLabel = "unk";
+
+} // namespace warc2text

--- a/src/lang.hh
+++ b/src/lang.hh
@@ -16,17 +16,17 @@ class LanguageDetector {
     virtual ~LanguageDetector() {};
 
     // detect language of plain text, return top languages
-    virtual bool detect(const std::string& text, std::unordered_map<std::string, std::string>& chunks) const = 0;
+    virtual void detect(const std::string& text, std::unordered_map<std::string, std::string>& chunks) const = 0;
+
+    // Label used for text (chunks) that cannot reliably be identified
+    static const std::string kUnknownLanguageLabel;
 };
 
 class FastTextDetector : public LanguageDetector {
   public:
     explicit FastTextDetector(const std::string &filename);
-
     virtual ~FastTextDetector();
-
-    // detect language of plain text, return top languages
-    virtual bool detect(const std::string& text, std::unordered_map<std::string, std::string>& chunks) const;
+    virtual void detect(const std::string& text, std::unordered_map<std::string, std::string>& chunks) const;
 
   private:
     std::unique_ptr<fasttext::FastText> classifier_;
@@ -34,13 +34,13 @@ class FastTextDetector : public LanguageDetector {
 
 class CLD2Detector : public LanguageDetector {
 public:
-  virtual bool detect(const std::string& text, std::unordered_map<std::string, std::string>& chunks) const;
+  virtual void detect(const std::string& text, std::unordered_map<std::string, std::string>& chunks) const;
   virtual ~CLD2Detector();
 };
 
 class CLD2MultiLangDetector : public LanguageDetector {
 public:
-  virtual bool detect(const std::string& text, std::unordered_map<std::string, std::string>& chunks) const;
+  virtual void detect(const std::string& text, std::unordered_map<std::string, std::string>& chunks) const;
   virtual ~CLD2MultiLangDetector();
 };
 

--- a/src/lang.hh
+++ b/src/lang.hh
@@ -1,18 +1,49 @@
 #ifndef WARC2TEXT_LANG_HH
 #define WARC2TEXT_LANG_HH
 
+#include <memory>
 #include <string>
 #include <unordered_map>
-#include <utility>
-#include "cld2/public/compact_lang_det.h"
-#include "cld2/public/encodings.h"
+
+namespace fasttext {
+class FastText;
+} // namespace fasttext
 
 namespace warc2text {
-    // detect language of plain text, return top 3 languages
-    bool detectLanguage(const std::string& text, std::unordered_map<std::string, std::string>& chunks);
 
-    // detect top language of plain text
-    bool detectLanguage(const std::string& text, std::string& lang);
-}
+class LanguageDetector {
+  public:
+    virtual ~LanguageDetector() {};
+
+    // detect language of plain text, return top languages
+    virtual bool detect(const std::string& text, std::unordered_map<std::string, std::string>& chunks) const = 0;
+};
+
+class FastTextDetector : public LanguageDetector {
+  public:
+    explicit FastTextDetector(const std::string &filename);
+
+    virtual ~FastTextDetector();
+
+    // detect language of plain text, return top languages
+    virtual bool detect(const std::string& text, std::unordered_map<std::string, std::string>& chunks) const;
+
+  private:
+    std::unique_ptr<fasttext::FastText> classifier_;
+};
+
+class CLD2Detector : public LanguageDetector {
+public:
+  virtual bool detect(const std::string& text, std::unordered_map<std::string, std::string>& chunks) const;
+  virtual ~CLD2Detector();
+};
+
+class CLD2MultiLangDetector : public LanguageDetector {
+public:
+  virtual bool detect(const std::string& text, std::unordered_map<std::string, std::string>& chunks) const;
+  virtual ~CLD2MultiLangDetector();
+};
+
+} // namespace warc2text
 
 #endif

--- a/src/lang_cld2.cc
+++ b/src/lang_cld2.cc
@@ -1,10 +1,24 @@
 #include "src/lang.hh"
+#include "cld2/public/compact_lang_det.h"
+#include "cld2/public/encodings.h"
 
 namespace warc2text {
     // hint = {content language code(s), tld, original encoding, CLD2::Language}
     const CLD2::CLDHints NO_HINT = {nullptr, nullptr, CLD2::UNKNOWN_ENCODING, CLD2::UNKNOWN_LANGUAGE};
 
-    bool detectLanguage(const std::string& text, std::unordered_map<std::string, std::string>& text_by_lang){
+    CLD2Detector::~CLD2Detector() {}
+
+    bool CLD2Detector::detect(const std::string& text, std::unordered_map<std::string, std::string>& text_by_lang) const {
+        bool reliable = false;
+        int valid_prefix_bytes = 0;
+        CLD2::Language l = CLD2::DetectLanguageCheckUTF8(text.data(), text.size(), true, &reliable, &valid_prefix_bytes);
+        text_by_lang[CLD2::LanguageCode(l)] = text;
+        return reliable;
+    }
+
+    CLD2MultiLangDetector::~CLD2MultiLangDetector() {}
+
+    bool CLD2MultiLangDetector::detect(const std::string& text, std::unordered_map<std::string, std::string>& text_by_lang) const {
         CLD2::Language langs[3] = {CLD2::UNKNOWN_LANGUAGE, CLD2::UNKNOWN_LANGUAGE, CLD2::UNKNOWN_LANGUAGE};
         int percents[3] = {0,0,0};
         double scores[3] = {0.0, 0.0, 0.0};
@@ -57,14 +71,6 @@ namespace warc2text {
 
         // TODO: do something with the scores?
 
-        return reliable;
-    }
-
-    bool detectLanguage(const std::string& text, std::string& lang){
-        bool reliable = false;
-        int valid_prefix_bytes = 0;
-        CLD2::Language l = CLD2::DetectLanguageCheckUTF8(text.data(), text.size(), true, &reliable, &valid_prefix_bytes);
-        lang = CLD2::LanguageCode(l);
         return reliable;
     }
 } // namespace warc2text

--- a/src/lang_cld2.cc
+++ b/src/lang_cld2.cc
@@ -8,17 +8,16 @@ namespace warc2text {
 
     CLD2Detector::~CLD2Detector() {}
 
-    bool CLD2Detector::detect(const std::string& text, std::unordered_map<std::string, std::string>& text_by_lang) const {
+    void CLD2Detector::detect(const std::string& text, std::unordered_map<std::string, std::string>& text_by_lang) const {
         bool reliable = false;
         int valid_prefix_bytes = 0;
         CLD2::Language l = CLD2::DetectLanguageCheckUTF8(text.data(), text.size(), true, &reliable, &valid_prefix_bytes);
-        text_by_lang[CLD2::LanguageCode(l)] = text;
-        return reliable;
+        text_by_lang[reliable ? CLD2::LanguageCode(l) : kUnknownLanguageLabel] = text;
     }
 
     CLD2MultiLangDetector::~CLD2MultiLangDetector() {}
 
-    bool CLD2MultiLangDetector::detect(const std::string& text, std::unordered_map<std::string, std::string>& text_by_lang) const {
+    void CLD2MultiLangDetector::detect(const std::string& text, std::unordered_map<std::string, std::string>& text_by_lang) const {
         CLD2::Language langs[3] = {CLD2::UNKNOWN_LANGUAGE, CLD2::UNKNOWN_LANGUAGE, CLD2::UNKNOWN_LANGUAGE};
         int percents[3] = {0,0,0};
         double scores[3] = {0.0, 0.0, 0.0};
@@ -33,7 +32,10 @@ namespace warc2text {
 
         text_by_lang.clear();
 
-        if (not reliable) return reliable;
+        if (not reliable) {
+            text_by_lang[kUnknownLanguageLabel] = text;
+            return;
+        }
 
         std::string* top1 = nullptr;
         std::string* top2 = nullptr;
@@ -70,7 +72,5 @@ namespace warc2text {
         }
 
         // TODO: do something with the scores?
-
-        return reliable;
     }
 } // namespace warc2text

--- a/src/lang_fasttext.cc
+++ b/src/lang_fasttext.cc
@@ -1,0 +1,40 @@
+#include "src/lang.hh"
+
+#include "fasttext.h"
+
+#include <cstdlib>
+#include <cstring>
+
+namespace warc2text {
+
+FastTextDetector::FastTextDetector(const std::string &filename)
+  : classifier_(new fasttext::FastText) {
+  classifier_->loadModel(filename);
+}
+
+FastTextDetector::~FastTextDetector() {}
+
+const char kLabelPrefix[] = "__label__";
+
+bool FastTextDetector::detect(const std::string& text, std::unordered_map<std::string, std::string>& chunks) const {
+  const float kThreshold = 0.5f;
+  std::vector<int32_t> words, labels;
+  classifier_->getDictionary()->getStringNoNewline(text, words, labels);
+  fasttext::Predictions predictions;
+  classifier_->predict(1, words, predictions, kThreshold);
+  if (predictions.empty()) return false;
+
+  // Labels look like __label__eng
+  std::string label = classifier_->getDictionary()->getLabel(predictions[0].second);
+  if (strncmp(label.c_str(), kLabelPrefix, sizeof(kLabelPrefix) - 1)) {
+    std::cerr << "Was expecting text classifier labels to begin with " << kLabelPrefix << " but they look like " << label << std::endl;
+    std::abort();
+  }
+  label.erase(0, sizeof(kLabelPrefix) - 1);
+
+  // For better or worse, we're currently doing everything as one chunk.
+  chunks[label] = text;
+  return true;
+}
+
+} // namespace warc2text

--- a/src/record.cc
+++ b/src/record.cc
@@ -233,10 +233,8 @@ namespace warc2text {
         return text_by_langs;
     }
 
-    int Record::detectLanguage(bool multilang){
-        if (not multilang) return warc2text::detectLanguage(plaintext, language);
-
-        warc2text::detectLanguage(plaintext, text_by_langs);
+    int Record::detectLanguage(LanguageDetector const &detector){
+        detector.detect(plaintext, text_by_langs);
         return text_by_langs.size();
     }
 

--- a/src/record.hh
+++ b/src/record.hh
@@ -38,7 +38,7 @@ namespace warc2text {
 
         int cleanPayload();
         int cleanPayload(const util::umap_tag_filters_regex& tagFilters);
-        int detectLanguage(bool multilang);
+        int detectLanguage(LanguageDetector const &detector);
 
         static std::string readZipPayload(const std::string& content_type, const std::string& payload);
         static std::string isPayloadZip(const std::string& content_type, const std::string& uri);

--- a/src/warcpreprocessor.cc
+++ b/src/warcpreprocessor.cc
@@ -169,7 +169,7 @@ namespace warc2text {
 
             langRecords += n_langs;
 
-            writer.write(record, true, paragraph_identification);
+            writer.write(record, paragraph_identification);
         }
         pdf_warc_writer.close();
     }

--- a/src/warcpreprocessor.cc
+++ b/src/warcpreprocessor.cc
@@ -8,10 +8,12 @@ namespace warc2text {
     const std::unordered_set<std::string> WARCPreprocessor::removeExtensions = {".jpg", ".jpeg", ".gif", ".png", ".css", ".js", ".mp3",
                                                                                 ".mp4", ".flv", ".wmv", ".gz", ".zip", ".rar" };
 
-    WARCPreprocessor::WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files,
+    WARCPreprocessor::WARCPreprocessor(const LanguageDetector &detector, 
+                                       const std::string& outputFolder, const std::unordered_set<std::string>& output_files,
                                        const std::string& pdf_warc_filename, const std::string& tagFiltersFile, bool invert,
-                                       const std::string& urlFiltersFile, bool multilang, bool encodeURLs,
+                                       const std::string& urlFiltersFile, bool encodeURLs,
                                        bool paragraph_identification) :
+        detector(detector),
         writer(outputFolder, output_files),
         totalRecords(0),
         textRecords(0),
@@ -22,7 +24,6 @@ namespace warc2text {
         tagFilters(),
         pdf_warc_filename(pdf_warc_filename),
         invert(invert),
-        multilang(multilang),
         encodeURLs(encodeURLs),
         paragraph_identification(paragraph_identification) {
             if (!tagFiltersFile.empty())
@@ -146,7 +147,7 @@ namespace warc2text {
             ++textRecords;
             textBytes += record.getPlainText().size();
 
-            n_langs = record.detectLanguage(multilang);
+            n_langs = record.detectLanguage(detector);
             if (n_langs == 1) {
                 langBytes += record.getPlainText().size();
             } else if (n_langs > 1) {
@@ -160,7 +161,7 @@ namespace warc2text {
 
             langRecords += n_langs;
 
-            writer.write(record, multilang, paragraph_identification);
+            writer.write(record, true, paragraph_identification);
         }
         pdf_warc_writer.close();
     }

--- a/src/warcpreprocessor.hh
+++ b/src/warcpreprocessor.hh
@@ -2,6 +2,7 @@
 #define WARC2TEXT_WARCPREPROCESSOR_HH
 
 #include "record.hh"
+#include "src/lang.hh"
 #include "warcreader.hh"
 #include "bilangwriter.hh"
 #include "util.hh"
@@ -24,6 +25,7 @@ namespace warc2text {
 
     class WARCPreprocessor {
         private:
+            LanguageDetector const &detector;
             BilangWriter writer;
             unsigned int totalRecords;
             unsigned int textRecords;
@@ -35,7 +37,6 @@ namespace warc2text {
             boost::regex urlFilter;
             std::string pdf_warc_filename;
             bool invert;
-            bool multilang;
             bool encodeURLs;
             bool paragraph_identification;
 
@@ -43,9 +44,10 @@ namespace warc2text {
             bool URLfilter(const std::string& url);
 
         public:
-            explicit WARCPreprocessor(const std::string& outputFolder, const std::unordered_set<std::string>& output_files = {},
+            explicit WARCPreprocessor(LanguageDetector const &detector,
+                                      const std::string& outputFolder, const std::unordered_set<std::string>& output_files = {},
                                       const std::string& pdf_warc_filename = "", const std::string& tagFiltersFile = "",
-                                      bool invert = false, const std::string& urlFiltersFile = "", bool multilang = false,
+                                      bool invert = false, const std::string& urlFiltersFile = "",
                                       bool encodeURLs = false, bool paragraph_identification = false);
             void process(const std::string &filename);
             void printStatistics() const;

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -8,6 +8,7 @@
 #include <boost/log/utility/setup/console.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include "src/lang.hh"
 #include "src/warcpreprocessor.hh"
 
 using namespace warc2text;
@@ -25,6 +26,8 @@ struct Options {
     std::string url_filters_filename;
     bool multilang{};
     bool encodeURLs{};
+    std::string classifier;
+    std::string fasttext_model;
 };
 
 void parseArgs(int argc, char *argv[], Options& out) {
@@ -43,6 +46,8 @@ void parseArgs(int argc, char *argv[], Options& out) {
         ("verbose,v", po::bool_switch(&out.verbose)->default_value(false), "Verbosity level")
         ("silent,s", po::bool_switch(&out.silent)->default_value(false))
         ("multilang", po::bool_switch(&out.multilang)->default_value(false), "Detect multiple languages in a single record")
+        ("classifier", po::value(&out.classifier)->default_value("cld2"), "Language classifier: cld2 or fasttext (default cld2)")
+        ("fasttext-model", po::value(&out.fasttext_model)->default_value(""), "Path to fasttext model")
         ("encode-urls", po::bool_switch(&out.encodeURLs)->default_value(false), "Encode URLs obtained from WARC records");
 
     po::positional_options_description pd;
@@ -58,6 +63,8 @@ void parseArgs(int argc, char *argv[], Options& out) {
                 " -f <output_files>                List of output files separated by commas\n"
                 "                                  Default (mandatory): \"url,text\"\n"
                 "                                  Optional values: \"mime,html\"\n"
+                " --classifier                     Classifier to use: cld2 or fasttext\n"
+                " --fasttext-model <model_file>    Path to FastText model for fasttext classifier\n"
                 " --multilang                      Detect multiple languages in documents (up to 3),\n"
                 "                                  write as many text records as languages detected\n"
                 " --tag-filters <filters_files>    File containing html tag filters\n"
@@ -94,9 +101,29 @@ int main(int argc, char *argv[]) {
     boost::algorithm::split(files_list, options.files, [](char c) {return c == ',';});
     std::unordered_set<std::string> output_files(files_list.begin(), files_list.end());
 
+    std::unique_ptr<LanguageDetector> detector;
+
+    if (options.classifier == "cld2") {
+        if (options.multilang) {
+            detector.reset(new CLD2MultiLangDetector());
+        } else {
+            detector.reset(new CLD2Detector());
+        }
+    } else if (options.classifier == "fasttext") {
+        if (options.multilang) {
+            BOOST_LOG_TRIVIAL(error) << "FastText classifier doesn't do multilang at the moment";
+            abort();
+        } else {
+            detector.reset(new FastTextDetector(options.fasttext_model));
+        }
+    } else {
+        BOOST_LOG_TRIVIAL(error) << "Unsupported classifier option";
+        abort();
+    }
+
     std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-    WARCPreprocessor warcpproc(options.output, output_files, options.pdf_warc_filename, options.tag_filters_filename,
-                               options.tag_filters_invert, options.url_filters_filename, options.multilang,
+    WARCPreprocessor warcpproc(*detector, options.output, output_files, options.pdf_warc_filename, options.tag_filters_filename,
+                               options.tag_filters_invert, options.url_filters_filename,
                                options.encodeURLs, options.paragraph_identification);
     for (const std::string& file : options.warcs){
         warcpproc.process(file);


### PR DESCRIPTION
This takes @kpu's work on using fasttext but adds it as an option alongside cld2. To make it easier to compare the two (or more, if we integrate more classifiers).

Currently in draft just to notify other followers of this work. The cld2 code path triggers a EXC_BAD_ACCESS at some point when writing to the url.gz file? It's a bit of a mystery, hence draft.

Edit for posterity:
```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x68)
    frame #0: 0x00007ff80c8d6d13 libsystem_c.dylib`flockfile + 18
libsystem_c.dylib`flockfile:
->  0x7ff80c8d6d13 <+18>: movq   0x68(%rbx), %rdi
    0x7ff80c8d6d17 <+22>: addq   $0x8, %rdi
    0x7ff80c8d6d1b <+26>: callq  0x7ff80c94691e            ; symbol stub for: pthread_mutex_lock
    0x7ff80c8d6d20 <+31>: callq  0x7ff80c94643e            ; symbol stub for: __error
Target 0: (warc2text) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x68)
  * frame #0: 0x00007ff80c8d6d13 libsystem_c.dylib`flockfile + 18
    frame #1: 0x00007ff80c8ebaea libsystem_c.dylib`fwrite + 66
    frame #2: 0x00000001000f0991 warc2text`warc2text::GzipWriter::compress(this=0x0000600003515db8, in="https://mt.wikipedia.org/wiki/Spe%C4%8Bjali:Statistika", size=54, flush=0) at bilangwriter.cc:43:13
    frame #3: 0x00000001000f0b20 warc2text`warc2text::GzipWriter::writeLine(this=0x0000600003515db8, text="https://mt.wikipedia.org/wiki/Spe%C4%8Bjali:Statistika") at bilangwriter.cc:65:15
    frame #4: 0x00000001000f0ff0 warc2text`warc2text::BilangWriter::write(this=0x00007ff7bfefe690, lang="mlt_Latn", b64text="U3RhdGlzdGlrYSAtIFdpa2lwZWRpamEKU3RhdGlzdGlrYQpBcWJlxbwgbGVqbjogbmF2aWdhenpqb25pLCBmaXR0ZXgKU3RhdGlzdGlrYSByZWxhdGF0YSBtYWwtcGHEoW5pClBhxKFuaSB0YScga29udGVudXQKMywyNDcKUGHEoW5pCihJbC1wYcShbmkga29sbGhhIGZpbC13aWtpLCBsaSBqaW5rbHVkdSBwYcShbmkgdGEnIGRpc2t1c3Nqb25pLCByaWluZGlyaXp6YW1lbnRpLCBldMSLLikKMTUsMDI0CkZhamxzIG10ZWxsYScKMSwxODUKU3RhdGlzdGlrYSB0YWwtaW1tb2RpZmlrYXIKTW9kaWZpa2kgbWlubiBtaW5kdSBsLVdpa2lwZWRpamEgYmRpZXQgaWwtZnVuempvbiB0YWfEp2hhCjI2MywwMTAKTWVkamEgdGEnIG1vZGlmaWtpIGt1bGwgcGHEoW5hCjE3LjUxClN0YXRpc3Rpa2EgdGFsLXV0ZW50ClV0ZW50aSByZcShaXN0cmF0aQoxMyw3NjYKVXRlbnRpIGF0dGl2aSAobGlzdGEgdGEnIG1lbWJyaSkKKFV0ZW50aSBsaSB3ZXR0cXUgYXp6am9uaSBmbC1hxKfEp2FyIDMwIGp1bSkKMjIKQm90IChsaXN0YSB0YScgbWVtYnJpKQo1MQpBbW1pbmlzdHJhdHVyaSAobGlzdGEgdGEnIG1lbWJyaSkKMwpCdXJva3JhdGkgKGxpc3RhIHRhJyBtZW1icmkpCjIKU3R3ZXR0aSAobGlzdGEgdGEnIG1lbWJyaSkKMApLcmVhdHVyaSB0YWwta29udGlqaWV0IChsaXN0YSB0YScgbWVtYnJpKQowCkltcG9ydGF0dXJpIChsaXN0YSB0YScgbWVtYnJpKQowCkltcG9ydGF0dXJpIHRyYW5zd2lraSAobGlzdGEgdGEnIG1lbWJyaSkKMAplxbxlbnpqb25pamlldCB0YWwt"..., url="https://mt.wikipedia.org/wiki/Spe%C4%8Bjali:Statistika", mime="text/html", b64html="") at bilangwriter.cc:90:16
    frame #5: 0x00000001000f1a35 warc2text`warc2text::BilangWriter::write(this=0x00007ff7bfefe690, record=0x00007ff7bfefe0f8, multilang=true, paragraph_identification=false) at bilangwriter.cc:128:23
    frame #6: 0x00000001000388e5 warc2text`warc2text::WARCPreprocessor::process(this=0x00007ff7bfefe688, filename="WIDE-20171230055008-00094.warc.gz") at warcpreprocessor.cc:164:20
    frame #7: 0x000000010000a861 warc2text`main(argc=8, argv=0x00007ff7bfefeeb0) at warc2text_main.cc:129:19
    frame #8: 0x00007ff80c6c9310 dyld`start + 2432
```