### PR TITLE
warc2html changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,13 @@ produce the following directory structure at the path specified by `--output`:
 - `./{lang}/html.gz` contains lines of base64 encoded HTML as returned by the server. For ePub, MS Office or ODF files this is the extracted XML.
 - `./{lang}/file.gz` contains the `{filename}:{offset}:{length}` pointer to the warc archive the record was extracted from. `{offset}` and `{length}` are of the compressed data, e.g. `tail -c+{offset} < {filename} | head -c{length} | gzip -cd` will give you the original record.
 - `./{lang}/date.gz` gives you the original crawl date/time as reported by the crawler. [This should be a UTC timestamp](https://iipc.github.io/warc-specifications/specifications/warc-format/warc-1.1/#warc-date-mandatory).
+- `./{lang}/metadata.jsonl.gz` contains the metadata as explained in the [JSONL section](#jsonl) below. Note that this output file will already contain some of the information described above, so `mime`, `url`, `file` and `date` are not needed when using `metadata`. Also note that this option will write **only** the metadata, so it will not include plain text or HTML.
 
 In every file, each line corresponds to the same record. E.g. the fifth line in `text.gz` and fifth line in `url.gz` together give you the text and url for a single record.
 
 The `{lang}` part of the path is determined by the classifier (see `--classifier`) and may be a two-letter or three-letter code depending on the classifier used. See [this list](https://github.com/CLD2Owners/cld2/blob/b56fa78a2fe44ac2851bae5bf4f4693a0644da7b/internal/generated_language.cc#L647-L1262) for CLD2. When skipping the language identification with `--classifier skip`, all the files will be written directly to output folder without creating language specific folders.
 
+### JSONL
 When using `--jsonl`, the output is instead a single JSON record per line, with the following keys (always in this order):
 ```ts
 {

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ warc2text -o <output_folder> [ -f <output_files> ] [ --pdfpass <output_warc> ]
 * `--encode-urls` Escape non-ascii characters that appear in the record URL with `%dd` encoding.
 * `--multilang` Detect multiple languages in the document, and split the document accordingly. Only supported with CLD2 classifier.
 * `--paragraph-identification` print the paragraph identifier for each sentence extracted from the HTML
-* `--classifier` classifier to use: `cld2` or `fasttext`. When `fasttext` is used, one also has to specify a model using `--fasttext-model`.
+* `--classifier` classifier to use: `cld2`, `fasttext`, or `skip`. When `fasttext` is used, one also has to specify a model using `--fasttext-model`. Use `skip` to skip language identification entirely.
 * `--fasttext-model` path to FastText model for fasttext classifier. Models can be any [FastText language identification model](https://fasttext.cc/docs/en/language-identification.html) such as [OpenLID lid201-model.ftz](https://github.com/laurieburchell/open-lid-dataset#quantised-model)
 * `--tag-filters` file containing filters that are used to eliminate matching documents
 * `--invert-tag-filters` output only documents that match the filter
@@ -78,7 +78,7 @@ produce the following directory structure at the path specified by `--output`:
 
 In every file, each line corresponds to the same record. E.g. the fifth line in `text.gz` and fifth line in `url.gz` together give you the text and url for a single record.
 
-The `{lang}` part of the path is determined by the classifier (see `--classifier`) and may be a two-letter or three-letter code depending on the classifier used. See [this list](https://github.com/CLD2Owners/cld2/blob/b56fa78a2fe44ac2851bae5bf4f4693a0644da7b/internal/generated_language.cc#L647-L1262) for CLD2.
+The `{lang}` part of the path is determined by the classifier (see `--classifier`) and may be a two-letter or three-letter code depending on the classifier used. See [this list](https://github.com/CLD2Owners/cld2/blob/b56fa78a2fe44ac2851bae5bf4f4693a0644da7b/internal/generated_language.cc#L647-L1262) for CLD2. When skipping the language identification with `--classifier skip`, all the files will be written directly to output folder without creating language specific folders.
 
 When using `--jsonl`, the output is instead a single JSON record per line, with the following keys (always in this order):
 ```ts
@@ -88,7 +88,7 @@ When using `--jsonl`, the output is instead a single JSON record per line, with 
   s:  number, # warc file record size (same as `{size}` in `file.gz`)
   rs: number, # byte size of record payload (uncompressed)
   ps: number, # byte size of text only payload (so compare this against `rs` and you should get amount of HTML removed)
-  l:  string, # identified language by classifier
+  l:  string, # identified language by classifier, omitted when language identification is skipped
   u:  string, # url
   c:  string, # content type as reported by the HTTP response header (or warc record header if that isn't present)
   ts: string, # crawl date/time as reported by the crawler

--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -142,18 +142,22 @@ namespace warc2text{
     void JSONLinesWriter::write(const Record& record, [[maybe_unused]] bool paragraph_identification) {
         // JSON lines format (https://jsonlines.org)
         for (auto &&chunk : record.getTextByLangs()) {
-            out_ << boost::json::value{
+            auto obj = boost::json::object{
                  {"f", boost::json::string(record.getFilename())},
                  {"o", boost::json::value(record.getOffset())},
                  {"s", boost::json::value(record.getSize())},
                  {"rs", boost::json::value(record.getPayload().size())},
                  {"ps", boost::json::value(chunk.second.size())},
-                 {"l", boost::json::string(chunk.first)},
                  {"u", boost::json::string(record.getURL())},
                  {"c", boost::json::string(record.getHTTPcontentType())},
                  {"ts", boost::json::string(record.getWARCdate())},
                  {"p", boost::json::string(chunk.second)},
-            } << "\n";
+            };
+            // Insert language if langid wasn't skipped
+            if(chunk.first != "")
+                obj["l"] = boost::json::string(chunk.first);
+
+            out_ << obj << "\n";
         }
     }
 }

--- a/src/bilangwriter.hh
+++ b/src/bilangwriter.hh
@@ -46,6 +46,7 @@ namespace warc2text {
      */
     class LangWriter {
         private:
+            GzipWriter metadata_file;
             GzipWriter url_file;
             GzipWriter mime_file;
             GzipWriter text_file;

--- a/src/lang.cc
+++ b/src/lang.cc
@@ -4,4 +4,14 @@ namespace warc2text {
 	
 const std::string LanguageDetector::kUnknownLanguageLabel = "unk";
 
+
+SkipLanguageDetector::~SkipLanguageDetector() {}
+
+void SkipLanguageDetector::detect(const std::string& text, std::unordered_map<std::string, std::string>& chunks) const {
+    // When skipping language detection, you may think "unk" should be the label used
+    // but this may seem as langid tried but only found unks.
+    // So leaving it as empty for now
+    chunks[""] = text;
+}
+
 } // namespace warc2text

--- a/src/lang.hh
+++ b/src/lang.hh
@@ -44,6 +44,12 @@ public:
   virtual ~CLD2MultiLangDetector();
 };
 
+class SkipLanguageDetector : public LanguageDetector {
+public:
+  virtual void detect(const std::string& text, std::unordered_map<std::string, std::string>& chunks) const;
+  virtual ~SkipLanguageDetector();
+};
+
 } // namespace warc2text
 
 #endif

--- a/src/record.cc
+++ b/src/record.cc
@@ -184,12 +184,12 @@ namespace warc2text {
         util::trim(cleanHTTPcontentType);
     }
 
-    int Record::cleanPayload(){
+    int Record::cleanPayload(bool skip_extraction){
         util::umap_tag_filters_regex tagFilters;
-        return cleanPayload(tagFilters);
+        return cleanPayload(tagFilters, skip_extraction);
     }
 
-    int Record::cleanPayload(const util::umap_tag_filters_regex& tagFilters){
+    int Record::cleanPayload(const util::umap_tag_filters_regex& tagFilters, bool skip_extraction){
 
         // we know for sure that HTTP content type is incorrect if it is present, and it is not 'text'
         bool nonTextHTTPcontentType = not cleanHTTPcontentType.empty() and textContentTypes.find(cleanHTTPcontentType) == textContentTypes.end();
@@ -218,6 +218,9 @@ namespace warc2text {
         bool isPlainText = cleanHTTPcontentType == "text/plain";
         
         int retval = util::SUCCESS;
+
+        if (skip_extraction)
+            return retval;
 
         // remove HTML tags:
         if (isPlainText) {

--- a/src/record.cc
+++ b/src/record.cc
@@ -220,8 +220,16 @@ namespace warc2text {
         
         int retval = util::SUCCESS;
 
-        if (skip_extraction)
+        if (skip_extraction) {
+            if (needToConvert) {
+                try {
+                    payload = util::toUTF8(payload, charset);
+                } catch (boost::locale::conv::conversion_error &e) {
+                    return util::UTF8_CONVERSION_ERROR;
+                }
+            }
             return retval;
+        }
 
         // remove HTML tags:
         if (isPlainText) {

--- a/src/record.hh
+++ b/src/record.hh
@@ -46,8 +46,8 @@ namespace warc2text {
         
         const std::unordered_map<std::string, std::string>& getTextByLangs() const;
 
-        int cleanPayload();
-        int cleanPayload(const util::umap_tag_filters_regex& tagFilters);
+        int cleanPayload(bool skip_extraction);
+        int cleanPayload(const util::umap_tag_filters_regex& tagFilters, bool skip_extraction);
         int detectLanguage(LanguageDetector const &detector);
 
         static std::string readZipPayload(const std::string& content_type, const std::string& payload);

--- a/src/util.cc
+++ b/src/util.cc
@@ -91,10 +91,10 @@ namespace util {
     }
 
     std::string toUTF8(const std::string& text, const std::string& charset) {
-        return boost::locale::conv::to_utf<char>(text, charset);
+        return boost::locale::conv::to_utf<char>(text, charset, boost::locale::conv::stop);
     }
     std::string toUTF8(const char* text, const std::string& charset) {
-        return boost::locale::conv::to_utf<char>(text, charset);
+        return boost::locale::conv::to_utf<char>(text, charset, boost::locale::conv::stop);
     }
 
     std::string encodeBase64(const std::string &original) {

--- a/src/warcpreprocessor.hh
+++ b/src/warcpreprocessor.hh
@@ -30,6 +30,7 @@ namespace warc2text {
         std::string robots_warc_filename;
         
         bool paragraph_identification{};
+        bool skip_text_extraction{};
 
         std::string output;
         std::unordered_set<std::string> output_files;

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -58,7 +58,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
                 " -f <output_files>                List of output files separated by commas\n"
                 "                                  Default (mandatory): \"url,text\"\n"
                 "                                  Optional values: \"mime,html,file,date\"\n"
-                " --classifier                     Classifier to use: cld2 or fasttext\n"
+                " --classifier                     Classifier to use: cld2, fasttext or skip\n"
                 " --fasttext-model <model_file>    Path to FastText model for fasttext classifier\n"
                 " --multilang                      Detect multiple languages in documents (up to 3),\n"
                 "                                  write as many text records as languages detected\n"
@@ -125,6 +125,11 @@ int main(int argc, char *argv[]) {
         } else {
             detector.reset(new FastTextDetector(options.fasttext_model));
         }
+    } else if (options.classifier == "skip") {
+        if (options.multilang) {
+            BOOST_LOG_TRIVIAL(error) << "Language identification is being skipped, ignoring --multilang option.";
+        }
+        detector.reset(new SkipLanguageDetector());
     } else {
         BOOST_LOG_TRIVIAL(error) << "Unsupported classifier option";
         abort();

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -37,6 +37,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
         ("pdfpass", po::value(&out.pdf_warc_filename), "Write PDF records to WARC")
         ("robotspass", po::value(&out.robots_warc_filename), "Write robots.txt records to WARC")
         ("paragraph-identification", po::bool_switch(&out.paragraph_identification)->default_value(false), "Add paragraph index in each b64encoded document as tab separated column")
+        ("skip-text-extraction", po::bool_switch(&out.skip_text_extraction)->default_value(false))
         ("verbose,v", po::bool_switch(&out.verbose)->default_value(false), "Verbosity level")
         ("silent,s", po::bool_switch(&out.silent)->default_value(false))
         ("multilang", po::bool_switch(&out.multilang)->default_value(false), "Detect multiple languages in a single record")
@@ -56,7 +57,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
                 "Options:\n"
                 " -o <output_folder>               Output folder, required\n"
                 " -f <output_files>                List of output files separated by commas\n"
-                "                                  Default (mandatory): \"url,text\"\n"
+                "                                  Default: \"url,text\"\n"
                 "                                  Optional values: \"mime,html,file,date\"\n"
                 " --classifier                     Classifier to use: cld2, fasttext or skip\n"
                 " --fasttext-model <model_file>    Path to FastText model for fasttext classifier\n"
@@ -71,6 +72,9 @@ void parseArgs(int argc, char *argv[], Options& out) {
                 " --robotspass <output_warc>       Write Robots.txt records to <output_warc>\n"
                 " --encode-urls                    Encode URLs obtained from WARC records\n"
                 " --paragraph-identification       Add paragraph index for each sentence extracted from the html\n"
+                " --skip-text-extraction           Skip text extraction and output only html\n"
+                "                                  This option is not compatible with \"text\" value in -f option \n"
+                "                                  and also requires to skip language identification\n"
                 " -s                               Only output errors\n"
                 " --jsonl                          Write JSONLines to stdout\n"
                 " -v                               Verbose output (print trace)\n\n";
@@ -97,6 +101,19 @@ int main(int argc, char *argv[]) {
     std::vector<std::string> files_list;
     boost::algorithm::split(files_list, options.files, [](char c) {return c == ',';});
     options.output_files.insert(files_list.begin(), files_list.end());
+
+    if (options.skip_text_extraction) {
+        if (options.files.find("text") != std::string::npos) {
+            BOOST_LOG_TRIVIAL(error) << "Cannot use 'text' as output file with '--skip-text-extraction'. Please use '-f url,html' or any other combination that does not include it.";
+            abort();
+        }
+        if (options.classifier != "skip") {
+            BOOST_LOG_TRIVIAL(error) << "When skipping text extraction, language identification cannot be performed. Please provide '--classifier skip' to skip language identification.";
+            abort();
+        }
+        if (options.tag_filters_filename != "")
+            BOOST_LOG_TRIVIAL(warning) << "If '--skip-text-extraction' is enabled, tag filters cannot be applied.";
+    }
 
     std::unique_ptr<RecordWriter> writer;
     if (options.jsonl) {

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -58,7 +58,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
                 " -o <output_folder>               Output folder, required\n"
                 " -f <output_files>                List of output files separated by commas\n"
                 "                                  Default: \"url,text\"\n"
-                "                                  Optional values: \"mime,html,file,date\"\n"
+                "                                  Optional values: \"mime,html,file,date,metadata\"\n"
                 " --classifier                     Classifier to use: cld2, fasttext or skip\n"
                 " --fasttext-model <model_file>    Path to FastText model for fasttext classifier\n"
                 " --multilang                      Detect multiple languages in documents (up to 3),\n"


### PR DESCRIPTION
As we've been [discussing](https://github.com/orgs/hplt-project/discussions/1) in HPLT, our first stage of the pipeline will probably be just an HTML extraction and metadata form WARCs. Excluding text extraction from HTML and language identification.

We firstly discussed that we may create a separate fork to do all of these things, but since I've been able to write the changes in a more or less clean way, with pluggable CLI options, I think it is reasonable to keep it in the main branch. The list of features this PR adds:

- `--classifier skip` to skip language identification entirely. When this is used, warc2text will write the output files directly in the output folder without any language specific folder. In the case of JSON output, the `l` filed will be omitted.
- `--skip-text-extraction` will skip HTML parsing for text extraction.
- `metadata` value for `-f`,`--files` that adds a `metadata.jsonl.gz` output file containing all the metadata. This differs from `--jsonl` option in that it does not include the plain text.

So, for example, to perform all the operations that we want for our first stage, the command would be:
```
warc2text -f html,metadata --skip-text-extraction --classifier skip --url-filter url_list.annotated -o output_folder file.warc.gz
```