### PR TITLE
ZSTD compression and compression level support

### DIFF
--- a/src/bilangwriter.cc
+++ b/src/bilangwriter.cc
@@ -3,81 +3,62 @@
 #include "util/exception.hh"
 #include <cassert>
 #include <string>
+#include <ostream>
 #include <iomanip>
+#include <boost/log/trivial.hpp>
 #include <boost/json.hpp>
+#include <boost/iostreams/filter/gzip.hpp>
+#include <boost/iostreams/filter/zstd.hpp>
+#include <boost/iostreams/copy.hpp>
+#include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
 
 
-namespace warc2text{
+namespace warc2text {
 
-    GzipWriter::GzipWriter()
-    : dest(nullptr),
-      buf(new unsigned char[BUFFER_SIZE]) {
-        //
+    CompressWriter::CompressWriter()
+    : file(),
+      compressor() {
+          compression = Compression::gzip;
+          level = 3;
     }
 
-    GzipWriter::~GzipWriter() {
-        if (is_open())
-            close();
-        delete[] buf;
+    CompressWriter::CompressWriter(Compression c, int l)
+    : file(),
+      compressor() {
+          compression = c;
+          level = l;
     }
 
-    void GzipWriter::compress(const char *in, std::size_t size, int flush) {
-        assert(is_open());
-        if (size == 0 && flush == Z_NO_FLUSH) return;
-        s.avail_in = size;
-        s.next_in = (Bytef *) in;
-        s.avail_out = 0;
-        s.next_out = buf;
-        int ret = Z_OK;
-        //std::size_t written;
-        while (s.avail_out == 0) {
-            s.avail_out = BUFFER_SIZE;
-            s.next_out = buf;
-            ret = deflate(&s, flush);
-            assert(ret == Z_OK || ret == Z_STREAM_END); // Z_STREAM_END only happens if flush == Z_FINISH
-            std::size_t compressed = BUFFER_SIZE - s.avail_out;
-            //written = std::fwrite(buf, 1, compressed, dest);
-            std::fwrite(buf, 1, compressed, dest);
-            // TODO error handling
-            // if (written != compressed || std::ferror(dest)) {
-            // }
+    CompressWriter::~CompressWriter() {
+        if (file.is_open()){
+            compressor.reset();
         }
-        assert(s.avail_in == 0);
     }
 
-    void GzipWriter::open(const std::string& filename) {
-        dest = std::fopen(filename.c_str(), "wb");
-        UTIL_THROW_IF(!dest, util::ErrnoException, "while creating " << filename);
-        s.zalloc = nullptr;
-        s.zfree = nullptr;
-        s.opaque = nullptr;
-        int ret = deflateInit2(&s, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY);
-        assert(ret == Z_OK);
+    void CompressWriter::open(const std::string &filename) {
+        file = std::ofstream(filename, std::ios_base::out | std::ios_base::binary);
+        switch(compression) {
+            case Compression::gzip:
+                compressor.push(bio::gzip_compressor(bio::gzip_params(level)));
+                break;
+            case Compression::zstd:
+                compressor.push(bio::zstd_compressor(bio::zstd_params(level)));
+                break;
+        }
+        compressor.push(file);
     }
 
-    void GzipWriter::close() {
-        compress("", 0, Z_FINISH);
-        deflateEnd(&s);
-        std::fclose(dest);
-        dest = nullptr;
+    void CompressWriter::writeLine(const std::string &text) {
+        // creating an ostream on each document write seems inefficient
+        // but ostream objects cannot be copyassigned and at the moment of construction
+        // we don't have the underlying compressor, so cannot declare in constructor
+        // and then assign to a new instance when in CompressWriter::open
+        std::ostream(&compressor) << text << "\n";
     }
 
-    void GzipWriter::write(const char* text, std::size_t size) {
-        compress(text, size, Z_NO_FLUSH);
-    }
-
-    void GzipWriter::writeLine(const char* text, std::size_t size) {
-        compress(text, size, Z_NO_FLUSH);
-        compress("\n", 1, Z_NO_FLUSH);
-    }
-
-    void GzipWriter::writeLine(const std::string& text) {
-        compress(text.c_str(), text.size(), Z_NO_FLUSH);
-        compress("\n", 1, Z_NO_FLUSH);
-    }
-
-    bool GzipWriter::is_open(){
-        return dest != nullptr;
+    bool CompressWriter::is_open() {
+        return file.is_open();
     }
 
     boost::json::object toJSON(Record const &record, std::string const &chunk, bool metadata_only) {
@@ -100,23 +81,32 @@ namespace warc2text{
         return obj;
     }
 
-    LangWriter::LangWriter(const std::string& path, const std::unordered_set<std::string>& output_files) {
+    LangWriter::LangWriter(const std::string& path, const std::unordered_set<std::string>& output_files,
+                           Compression c, int l)
+    : metadata_file(c,l), url_file(c,l), mime_file(c,l), text_file(c,l), html_file(c,l), file_file(c,l), date_file(c,l)
+    {
         util::createDirectories(path);
 
+        std::string suffix;
+        switch(c) {
+            case Compression::zstd: suffix = ".zst"; break;
+            case Compression::gzip: suffix = ".gz"; break;
+        }
+
         if (output_files.count("metadata"))
-            metadata_file.open(path + "/metadata.jsonl.gz");
+            metadata_file.open(path + "/metadata.jsonl" + suffix);
         if (output_files.count("url"))
-            url_file.open(path + "/url.gz");
+            url_file.open(path + "/url" + suffix);
         if (output_files.count("text"))
-            text_file.open(path + "/text.gz");
+            text_file.open(path + "/text" + suffix);
         if (output_files.count("mime"))
-            mime_file.open(path + "/mime.gz");
+            mime_file.open(path + "/mime" + suffix);
         if (output_files.count("html"))
-            html_file.open(path + "/html.gz");
+            html_file.open(path + "/html" + suffix);
         if (output_files.count("file"))
-            file_file.open(path + "/file.gz");
+            file_file.open(path + "/file" + suffix);
         if (output_files.count("date"))
-            date_file.open(path + "/date.gz");
+            date_file.open(path + "/date" + suffix);
     }
 
     void LangWriter::write(Record const &record, std::string const &chunk) {
@@ -158,7 +148,7 @@ namespace warc2text{
             if (paragraph_identification)
                 chunk = get_paragraph_id(chunk);
 
-            auto writer_it = writers.try_emplace(it.first, folder + "/" + it.first, output_files);
+            auto writer_it = writers.try_emplace(it.first, folder + "/" + it.first, output_files, compression, level);
             writer_it.first->second.write(record, chunk);
         }
     }
@@ -177,6 +167,23 @@ namespace warc2text{
 
             out_ << obj << "\n";
         }
+    }
+
+    std::istream& operator>>(std::istream& in, Compression &c) {
+        std::string token;
+        in >> token;
+        boost::algorithm::to_lower(token);
+        namespace po = boost::program_options;
+
+        if (token == "zstd") {
+            c = Compression::zstd;
+        } else if ("gzip"){
+            c = Compression::gzip;
+        } else {
+            throw po::validation_error(po::validation_error::invalid_option_value);
+        }
+
+        return in;
     }
 }
 

--- a/src/bilangwriter.hh
+++ b/src/bilangwriter.hh
@@ -3,11 +3,17 @@
 
 #include <unordered_map>
 #include <unordered_set>
-#include <ostream>
+#include <sstream>
+#include <fstream>
 #include "record.hh"
 #include "zlib.h"
+#include "boost/iostreams/filtering_streambuf.hpp"
 
 namespace warc2text {
+
+    namespace bio = boost::iostreams;
+
+    enum class Compression { zstd, gzip };
 
     /**
      * Generic interface for writing records to some form of output.
@@ -22,23 +28,21 @@ namespace warc2text {
      * Writer used by BilangWriter to write a single compressed file
      * (i.e. a column for a specific language)
      */
-    class GzipWriter {
+    class CompressWriter {
         private:
-            FILE* dest;
-            z_stream s{};
-            unsigned char* buf;
-            void compress(const char* in, std::size_t size, int flush);
+            std::ofstream file;
+            bio::filtering_streambuf<bio::output> compressor;
+            Compression compression;
+            int level;
 
         public:
-            GzipWriter();
-            ~GzipWriter();
+            CompressWriter();
+            CompressWriter(Compression c, int l);
+            ~CompressWriter();
             void open(const std::string& filename);
             void close();
-            void write(const char* text, std::size_t size);
-            void writeLine(const char* text, std::size_t size);
             void writeLine(const std::string& text);
             bool is_open();
-            static const std::size_t BUFFER_SIZE = 4096;
     };
 
     /**
@@ -46,15 +50,16 @@ namespace warc2text {
      */
     class LangWriter {
         private:
-            GzipWriter metadata_file;
-            GzipWriter url_file;
-            GzipWriter mime_file;
-            GzipWriter text_file;
-            GzipWriter html_file;
-            GzipWriter file_file;
-            GzipWriter date_file;
+            CompressWriter metadata_file;
+            CompressWriter url_file;
+            CompressWriter mime_file;
+            CompressWriter text_file;
+            CompressWriter html_file;
+            CompressWriter file_file;
+            CompressWriter date_file;
         public:
-            LangWriter(const std::string& folder, const std::unordered_set<std::string>& output_files);
+            LangWriter(const std::string& folder, const std::unordered_set<std::string>& output_files,
+                       Compression c = Compression::gzip, int l = 3);
             void write(const Record& record, const std::string &chunk);
     };
 
@@ -63,10 +68,12 @@ namespace warc2text {
             std::string folder;
             std::unordered_set<std::string> output_files;
             std::unordered_map<std::string, LangWriter> writers;
+            Compression compression;
+            int level;
         public:
-            BilangWriter(const std::string& folder, const std::unordered_set<std::string>& output_files = {})
-            : folder(folder)
-            , output_files(output_files)
+            BilangWriter(const std::string& folder, const std::unordered_set<std::string>& output_files = {},
+                         Compression c = Compression::gzip, int l = 3)
+            : folder(folder) , output_files(output_files) , compression(c) , level(l)
             {
                 //
             };


### PR DESCRIPTION
Now the user can choose between ZSTD or GZIP compression format (GZIP being default) and compression level. This change is made upon #50 because it is a feature that we may really need if we use HTML output, that is considerably taking more space than only text.

The code has been changed to use `boost::filtering_streambuf` to easily switch between algorithms, removing the old `GzipWriter` class that was handling compression more manually.

To see the real differences of this PR see https://github.com/bitextor/warc2text/pull/51/commits/53709d06456b8e357fe93ce6ebb12b078ecd3084