### PR TITLE
Move JSONL output to --stdout and allow file-based output with JSONL

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,11 @@ In every file, each line corresponds to the same record. E.g. the fifth line in 
 The `{lang}` part of the path is determined by the classifier (see `--classifier`) and may be a two-letter or three-letter code depending on the classifier used. See [this list](https://github.com/CLD2Owners/cld2/blob/b56fa78a2fe44ac2851bae5bf4f4693a0644da7b/internal/generated_language.cc#L647-L1262) for CLD2. When skipping the language identification with `--classifier skip`, all the files will be written directly to output folder without creating language specific folders.
 
 ### JSONL
-When using `--jsonl`, the output is instead a single JSON record per line, with the following keys (always in this order):
+When using `--jsonl`, the output files that previously were encoded in base64, are now written in a single JSON record per line.
+With the keys `"h"` and `"p"` for the `html` file and the `text` file respectively.
+
+#### stdout
+Instead of the classic Bitextor directory structure and files, the `--jsonl` option can be combined with `--stdout` to write all the output to stdout, with the following keys (always in this order):
 ```ts
 {
   f:  string, # filename of warc file (same as the `{filename}` part in `file.gz`)
@@ -98,7 +102,7 @@ When using `--jsonl`, the output is instead a single JSON record per line, with 
 }
 ```
 
-More keys might be added in the future (e.g. the raw HTML is not included now) and you should not expect the order of the keys to stay the same between different versions of warc2text.
+More keys might be added in the future (e.g. the raw HTML is not included in JSONL to stdout now) and you should not expect the order of the keys to stay the same between different versions of warc2text.
 
 ## Included dependencies
 HTML Tokenizer by [c-smile](https://www.codeproject.com/Articles/14076/Fast-and-Compact-HTML-XML-Scanner-Tokenizer)

--- a/src/bilangwriter.hh
+++ b/src/bilangwriter.hh
@@ -15,6 +15,8 @@ namespace warc2text {
 
     enum class Compression { zstd, gzip };
 
+    enum class Format { b64, json };
+
     /**
      * Generic interface for writing records to some form of output.
      */
@@ -57,9 +59,12 @@ namespace warc2text {
             CompressWriter html_file;
             CompressWriter file_file;
             CompressWriter date_file;
+            Format format;
+
+            std::string format_text(const std::string &text, std::string field_name);
         public:
             LangWriter(const std::string& folder, const std::unordered_set<std::string>& output_files,
-                       Compression c = Compression::gzip, int l = 3);
+                       Compression c = Compression::gzip, int l = 3, Format f = Format::b64);
             void write(const Record& record, const std::string &chunk);
     };
 
@@ -70,10 +75,11 @@ namespace warc2text {
             std::unordered_map<std::string, LangWriter> writers;
             Compression compression;
             int level;
+            Format format;
         public:
             BilangWriter(const std::string& folder, const std::unordered_set<std::string>& output_files = {},
-                         Compression c = Compression::gzip, int l = 3)
-            : folder(folder) , output_files(output_files) , compression(c) , level(l)
+                         Compression c = Compression::gzip, int l = 3, Format f = Format::b64)
+            : folder(folder) , output_files(output_files) , compression(c) , level(l), format(f)
             {
                 //
             };

--- a/warc2text_main.cc
+++ b/warc2text_main.cc
@@ -16,6 +16,7 @@ using namespace warc2text;
 struct Options : WARCPreprocessorOptions {
     std::vector<std::string> warcs;
     std::string files;
+    bool stdout{};
     bool verbose{};
     bool silent{};
     bool jsonl{};
@@ -31,6 +32,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
     desc.add_options()
         ("help,h", po::bool_switch(), "Show this help message")
         ("output,o", po::value(&out.output)->default_value("."), "Output folder")
+        ("stdout", po::bool_switch(&out.stdout)->default_value(false), "Write to standard output, only valid with --jsonl")
         ("files,f", po::value(&out.files)->default_value("url,text"), "List of output files separated by commas. Default: 'url,text'. Optional: 'mime,html,file'")
         ("input,i", po::value(&out.warcs)->multitoken(), "Input WARC file name(s)")
         ("tag-filters", po::value(&out.tag_filters_filename), "Plain text file containing tag filters")
@@ -43,7 +45,7 @@ void parseArgs(int argc, char *argv[], Options& out) {
         ("verbose,v", po::bool_switch(&out.verbose)->default_value(false), "Verbosity level")
         ("silent,s", po::bool_switch(&out.silent)->default_value(false))
         ("multilang", po::bool_switch(&out.multilang)->default_value(false), "Detect multiple languages in a single record")
-        ("jsonl", po::bool_switch(&out.jsonl)->default_value(false), "Output jsonl to stdout")
+        ("jsonl", po::bool_switch(&out.jsonl)->default_value(false), "Output in jsonl format")
         ("classifier", po::value(&out.classifier)->default_value("cld2"), "Language classifier: cld2 or fasttext (default cld2)")
         ("fasttext-model", po::value(&out.fasttext_model)->default_value(""), "Path to fasttext model")
         ("encode-urls", po::bool_switch(&out.encodeURLs)->default_value(false), "Encode URLs obtained from WARC records")
@@ -134,10 +136,13 @@ int main(int argc, char *argv[]) {
     }
 
     std::unique_ptr<RecordWriter> writer;
-    if (options.jsonl) {
+    if (options.jsonl && options.stdout) {
         writer = std::make_unique<JSONLinesWriter>(std::cout);
     } else if (!options.output_files.empty()) {
-        writer = std::make_unique<BilangWriter>(options.output, options.output_files, compression, options.compress_level);
+        Format format = Format::b64;
+        if (options.jsonl)
+            format = Format::json;
+        writer = std::make_unique<BilangWriter>(options.output, options.output_files, compression, options.compress_level, format);
     } else {
         BOOST_LOG_TRIVIAL(error) << "No output files specified";
         abort();


### PR DESCRIPTION
This changes the behaviour of the --jsonl option. Now the option only changes the output format to JSONL but not the output location. To write JSONL with all the metadata and text to stdout use along with --stdout. Otherwise it will change he files that are base64 encoded (html, text) to jsonl format.

This change allows us in HPLT to take advantage of higher compression ratios when saving HTML in escaped inside a JSON, instead of base64, who has way worse compression ratios (as mentioned in #34).

To see the real changes of this PR: https://github.com/bitextor/warc2text/commit/f4e2a8303add5d10c115fb91a811efb6163b291b
