### PR TITLE
Replacing boost::json with nlohmann::json

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,6 @@
 [submodule "fasttext"]
 	path = fasttext
 	url = https://github.com/kpu/fasterText.git
+[submodule "nlohmann_json"]
+	path = nlohmann_json
+	url = https://github.com/nlohmann/json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(warc2text)
 
 set(CMAKE_CXX_STANDARD 17)
+set(JSON_BuildTests OFF CACHE INTERNAL "")
 
 
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
@@ -16,7 +17,7 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif ()
 
-find_package(Boost 1.75 COMPONENTS program_options json log log_setup REQUIRED)
+find_package(Boost 1.71 COMPONENTS program_options log log_setup REQUIRED)
 
 # compile executable into bin/
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
@@ -50,6 +51,7 @@ target_include_directories(warc2text_lib PRIVATE fasttext/src)
 # add libcld2.so
 add_subdirectory(cld2)
 add_subdirectory(fasttext EXCLUDE_FROM_ALL)
+add_subdirectory(nlohmann_json)
 #
 
 # define executables
@@ -60,6 +62,7 @@ target_link_libraries(warc2text
     cld2_full
     fasttext-static
 )
+target_link_libraries(warc2text PRIVATE nlohmann_json::nlohmann_json)
 
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.10)
 
 project(warc2text)
 
@@ -57,12 +57,12 @@ add_subdirectory(nlohmann_json)
 # define executables
 add_executable(warc2text warc2text_main.cc)
 target_link_libraries(warc2text
-    warc2text_lib
-    ${Boost_LIBRARIES}
-    cld2_full
-    fasttext-static
+    PRIVATE warc2text_lib
+    PRIVATE ${Boost_LIBRARIES}
+    PRIVATE cld2_full
+    PRIVATE fasttext-static
+    PRIVATE nlohmann_json::nlohmann_json
 )
-target_link_libraries(warc2text PRIVATE nlohmann_json::nlohmann_json)
 
 include(GNUInstallDirs)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.10)
 
 project(warc2text_src)
 
@@ -38,22 +38,21 @@ add_library(warc2text_lib
 
 if (APPLE)
 	target_link_libraries(warc2text_lib
-		/usr/local/opt/libzip/lib/libzip.dylib)
+            PRIVATE /usr/local/opt/libzip/lib/libzip.dylib)
 elseif(LIBZIP_PATH)
 	target_link_libraries(warc2text_lib
-		${LIBZIP_PATH})
+            PRIVATE ${LIBZIP_PATH})
 else()
 	target_link_libraries(warc2text_lib
-		zip)
+            PRIVATE zip)
 
 endif()
 
 target_link_libraries(warc2text_lib
-    base64
-    preprocess_util
-    ${Boost_LIBRARIES}
-    ${ZLIB_LIBRARIES}
-    ${uchardet_LIBRARIES}
+    PRIVATE base64
+    PRIVATE preprocess_util
+    PRIVATE ${Boost_LIBRARIES}
+    PRIVATE ${ZLIB_LIBRARIES}
+    PRIVATE ${uchardet_LIBRARIES}
+    PRIVATE nlohmann_json::nlohmann_json
 )
-target_link_libraries(warc2text_lib PRIVATE nlohmann_json::nlohmann_json)
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,4 +55,5 @@ target_link_libraries(warc2text_lib
     ${ZLIB_LIBRARIES}
     ${uchardet_LIBRARIES}
 )
+target_link_libraries(warc2text_lib PRIVATE nlohmann_json::nlohmann_json)
 


### PR DESCRIPTION
Changes introduced with this new library migration:
- Strict UTF-8 encoding for JSON outputs.
- Different ways of managing UTF-8 encoding errors: replace errors, discard record, omit bad chars.
- Lower Boost minimum version (1.71 instead of 1.75). This allows compilation with the current boost in Ubuntu 22 and 20, which is 1.74.

Doing the PR with this branch because `nlohmann_json` branch commits are messed up.